### PR TITLE
Fix Jules Panel activities bug and UI visibility logic

### DIFF
--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -13,7 +13,7 @@ permalink: /jules-panel/
 </div>
 
 <!-- Access Restricted Gate -->
-<div id="jules-auth-gate" class="bg-slate-950 text-slate-100 min-h-[80vh] flex items-center justify-center hidden" style="display:none">
+<div id="jules-auth-gate" class="bg-slate-950 text-slate-100 min-h-[80vh] flex items-center justify-center hidden">
     <div class="text-center">
         <div class="text-purple-500 text-6xl mb-6"><i class="fa-solid fa-lock"></i></div>
         <h1 class="text-3xl font-bold mb-2">Acceso Restringido</h1>
@@ -25,7 +25,7 @@ permalink: /jules-panel/
 </div>
 
 <!-- Main Jules Panel -->
-<div id="jules-main-panel" class="jules-panel-container hidden" style="display:none">
+<div id="jules-main-panel" class="jules-panel-container hidden">
 
     <!-- Header Section -->
     <header class="panel-header">
@@ -792,41 +792,29 @@ permalink: /jules-panel/
     // --- INITIALIZATION ---
     async function initJulesPanel(user) {
         const loading = document.getElementById("auth-loading");
-        const gate = document.getElementById("jules-auth-gate");
-        const panel = document.getElementById("jules-main-panel");
+        const gate    = document.getElementById("jules-auth-gate");
+        const panel   = document.getElementById("jules-main-panel");
 
-        const token = sessionStorage.getItem("gh_access_token") || localStorage.getItem("github_token");
-        if (!token) {
-            loading.classList.add('hidden');
+        loading.classList.add('hidden');
+
+        const token = sessionStorage.getItem("gh_access_token")
+                   || localStorage.getItem("github_token");
+
+        if (!token || !user) {
             gate.classList.remove('hidden');
-            gate.style.display = 'flex';
-            panel.style.display = 'none';
+            panel.classList.add('hidden');
             return;
         }
 
-        try {
-            const { valid } = await window.githubApi.validateToken();
-            loading.classList.add('hidden');
+        // Usuario válido — mostrar panel
+        gate.classList.add('hidden');
+        panel.classList.remove('hidden');
 
-            if (valid) {
-                gate.style.display = 'none';
-                panel.classList.remove('hidden');
-                panel.style.display = 'block';
-
-                updateKeyState();
-                if (window.julesApi.apiKey) {
-                    initializeRepoSelector();
-                    refreshSessions();
-                    startPolling();
-                }
-            } else {
-                gate.classList.remove('hidden');
-                gate.style.display = 'flex';
-            }
-        } catch (e) {
-            loading.classList.add('hidden');
-            gate.classList.remove('hidden');
-            gate.style.display = 'flex';
+        updateKeyState();
+        if (window.julesApi.apiKey) {
+            initializeRepoSelector();
+            refreshSessions();
+            startPolling();
         }
     }
 
@@ -1393,34 +1381,40 @@ permalink: /jules-panel/
                 .map(el => el.dataset.activityId)
             );
 
-            // Solo añadir las NUEVAS — nunca reconstruir todo (Mejora 2 FIX)
+            // Quitar el placeholder "No hay eventos" si existen actividades reales
+            const placeholder = log.querySelector('[data-placeholder]');
+            if (placeholder && activities.length > 0) placeholder.remove();
+
+            // Añadir SOLO las actividades nuevas
             let added = false;
             activities.forEach(activity => {
-              if (!existingIds.has(activity.id)) {
-                const html = renderActivity(activity);
-                if (!html) return;
-                const div = document.createElement('div');
-                div.dataset.activityId = activity.id;
-                div.innerHTML = html;
-                log.appendChild(div);
-                added = true;
-              }
+              if (existingIds.has(activity.id)) return;
+              const html = renderActivity(activity);
+              if (!html) return;
+              const div = document.createElement('div');
+              div.dataset.activityId = activity.id;
+              div.innerHTML = html;
+              log.appendChild(div);
+              added = true;
             });
 
-            if (log.children.length === 0 && activities.length === 0) {
-              log.innerHTML = '<div class="activity-log italic text-center opacity-40">No hay eventos todavía</div>';
-            } else if (log.querySelector('.opacity-40') && activities.length > 0) {
-              log.innerHTML = ''; // Limpiar mensaje vacío
-              // Forzar re-renderizado en la siguiente pasada para este caso borde
+            // Mostrar placeholder solo si el log sigue vacío después de intentar añadir
+            if (log.querySelectorAll('[data-activity-id]').length === 0) {
+              if (!log.querySelector('[data-placeholder]')) {
+                const ph = document.createElement('div');
+                ph.dataset.placeholder = 'true';
+                ph.className = 'italic text-center opacity-40';
+                ph.style.cssText = 'font-size:11px;padding:12px;color:#4b5563;';
+                ph.textContent = 'No hay eventos todavía';
+                log.appendChild(ph);
+              }
             }
 
-            // Scroll inteligente solo si se añadió contenido nuevo
+            // Scroll inteligente
             if (added) {
               const threshold = 40;
               const isAtBottom = log.scrollHeight - log.scrollTop - log.clientHeight < threshold;
-              if (isAtBottom) {
-                log.scrollTo({ top: log.scrollHeight, behavior: 'smooth' });
-              }
+              if (isAtBottom) log.scrollTo({ top: log.scrollHeight, behavior: 'smooth' });
             }
         } catch (e) {
             console.warn("refreshActivities error:", e);
@@ -1792,9 +1786,9 @@ permalink: /jules-panel/
     (function arrancarPanel() {
       function iniciar(user) {
         const loading = document.getElementById('auth-loading');
-        if (loading) loading.style.display = 'none';
+        if (loading) loading.classList.add('hidden');
         const panel = document.getElementById('jules-main-panel');
-        if (panel) panel.style.display = 'block';
+        if (panel) panel.classList.remove('hidden');
 
         try { window.julesSessionsCache = window.julesSessionsCache || []; }
         catch(e) {}


### PR DESCRIPTION
This PR addresses three critical bugs in the Jules Panel:
1. **Activity History Bug**: The history panel would get "stuck" when transitioning from an empty state to having activities because it cleared the log but didn't render new items in the same cycle. Now uses surgical manipulation.
2. **Redundant Validation**: Startup was slowed down by an unnecessary call to \`validateToken\` which was already handled by \`auth.js\`.
3. **UI Consistency**: Mixed usage of \`style.display\` and \`.hidden\` class was causing potential specificity conflicts. All primary container transitions now use \`classList\` and a robust \`.hidden { display: none !important; }\` rule.

---
*PR created automatically by Jules for task [13138120056096767822](https://jules.google.com/task/13138120056096767822) started by @Axlfc*