### PR TITLE
Remove Jules navigation item from dashboard

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -63,10 +63,14 @@ permalink: /CHANGELOG.html
         <div class="card mb-3">
           <div class="card-body">
             <h5 class="text-success">Added</h5>
-            <ul class="tree-view mb-0">
+            <ul class="tree-view mb-3">
               <li>TortoiseSVN onboarding section and collaborative workflow guide in <code>guia-ue5-svn.html</code></li>
               <li><code>plan_de_arranque.html</code> unified with platform design system</li>
               <li>CHANGELOG enforcement GitHub Action</li>
+            </ul>
+            <h5 class="text-danger">Removed</h5>
+            <ul class="tree-view mb-0">
+              <li>"JULES" navigation item from the dashboard menu to eliminate duplication with "Quick Jules" button.</li>
             </ul>
           </div>
         </div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -36,7 +36,6 @@
                 <a href="#pipeline" class="text-xs font-bold text-slate-400 hover:text-white transition-all uppercase">Pipeline</a>
                 <a href="#charts" class="text-xs font-bold text-slate-400 hover:text-white transition-all uppercase">Analytics</a>
                 <a href="/tech-stack/" class="text-xs font-bold text-slate-400 hover:text-white transition-all uppercase">Tech Stack</a>
-                <a href="/jules-panel/" class="text-xs font-bold text-slate-400 hover:text-white transition-all uppercase">Jules</a>
             </div>
             <div id="member-filters" class="flex items-center gap-2 bg-slate-950 p-1 rounded-lg border border-slate-800">
                 <!-- Member filters injected here -->


### PR DESCRIPTION
Removed the "JULES" navigation item from the dashboard's main menu (KANBAN | PIPELINE | ANALYTICS | TECH STACK) while keeping the "Quick Jules" button. Verified visually that the menu now correctly displays the remaining items and that the "Quick Jules" button is still functional in its separate location.

---
*PR created automatically by Jules for task [6463623378880421841](https://jules.google.com/task/6463623378880421841) started by @Axlfc*