### PR TITLE
Fix Markdown rendering in progressUpdated and sessionCompleted activities

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -68,6 +68,10 @@ permalink: /CHANGELOG.html
               <li><code>plan_de_arranque.html</code> unified with platform design system</li>
               <li>CHANGELOG enforcement GitHub Action</li>
             </ul>
+            <h5 class="text-danger">Fixed</h5>
+            <ul class="tree-view mb-3">
+              <li>Markdown rendering in <code>progressUpdated</code> and <code>sessionCompleted</code> activities in Jules Panel.</li>
+            </ul>
             <h5 class="text-danger">Removed</h5>
             <ul class="tree-view mb-0">
               <li>"JULES" navigation item from the dashboard menu to eliminate duplication with "Quick Jules" button.</li>

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -1751,15 +1751,18 @@ permalink: /jules-panel/
         const title = activity.progressUpdated.title || '';
         const desc  = activity.progressUpdated.description || '';
 
-        // Buscar bashOutput en artifacts de esta actividad
+        const parsedTitle = typeof marked !== 'undefined' ? marked.parse(title) : escapeHtml(title);
+        const parsedDesc  = typeof marked !== 'undefined' && desc ? marked.parse(desc) : escapeHtml(desc);
+
         const bash = (activity.artifacts || [])
           .map(a => a.bashOutput).filter(Boolean)[0];
 
         html = `
           <div class="activity-entry activity-entry--progress">
-            <div style="color:#9ca3af;font-size:11px;">
-              ⚙️ <strong style="color:#d1d5db;">${escapeHtml(title)}</strong>
-              ${desc ? `<span style="color:#6b7280"> — ${escapeHtml(desc)}</span>` : ''}
+            <div class="prose" style="overflow-x:auto;max-width:100%;word-break:break-word;font-size:12px;">
+              <span style="color:#8b5cf6;font-weight:700;">⚙️</span>
+              ${parsedTitle}
+              ${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">${parsedDesc}</div>` : ''}
             </div>
             ${bash ? `
               <details style="margin-top:6px;">
@@ -1775,10 +1778,22 @@ permalink: /jules-panel/
       }
 
       else if (activity.sessionCompleted) {
-        html = `<div class="activity-entry"
-                     style="color:#10b981;font-size:11px;font-weight:600;">
-          🏁 Sesión completada
-        </div>`;
+        const commitMsg = activity.sessionCompleted?.commitMessage ||
+                          activity.sessionCompleted?.message || '';
+        const parsed = typeof marked !== 'undefined' && commitMsg
+          ? marked.parse(commitMsg)
+          : '';
+
+        html = `
+          <div class="activity-entry" style="color:#10b981;font-size:11px;font-weight:600;">
+            🏁 Sesión completada
+            ${parsed ? `
+              <div class="prose" style="overflow-x:auto;max-width:100%;word-break:break-word;
+                   font-size:11px;font-weight:400;color:#d1d5db;margin-top:6px;
+                   border-top:1px solid #1e1e2a;padding-top:6px;">
+                ${parsed}
+              </div>` : ''}
+          </div>`;
       }
 
       else if (activity.sessionFailed) {


### PR DESCRIPTION
Applied `marked.parse()` to the `progressUpdated` (title and description) and `sessionCompleted` (commit message) activity types in `pages/jules-panel.html` to ensure proper Markdown rendering instead of plain escaped strings. This change fixes issues where formatted text appeared as unformatted one-liners and list formatting was lost. Verified the rendering with a Playwright script and manual inspection of the generated screenshot.

---
*PR created automatically by Jules for task [6489836408355970158](https://jules.google.com/task/6489836408355970158) started by @Axlfc*