### PR TITLE
JULES — Fix cosmético: título duplicado y nav item activo en Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -71,6 +71,8 @@ permalink: /CHANGELOG.html
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
               <li>Markdown rendering in <code>progressUpdated</code> and <code>sessionCompleted</code> activities in Jules Panel.</li>
+              <li>Removed duplicate "Jules Panel" title rendered by the Jekyll layout.</li>
+              <li>Applied active state and disabled link for "Jules" in the navbar when on the Jules Panel page.</li>
             </ul>
             <h5 class="text-danger">Removed</h5>
             <ul class="tree-view mb-0">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,8 +34,8 @@
         <li class="nav-item">
           <a class="nav-link" href="{{ '/tech-stack/' | relative_url }}">Tech Stack</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/jules-panel/' | relative_url }}">Jules</a>
+        <li class="nav-item {% if page.url == '/jules-panel/' %}active{% endif %}">
+          <a class="nav-link" href="{{ '/jules-panel/' | relative_url }}" {% if page.url == '/jules-panel/' %}style="pointer-events: none; opacity: 0.5;"{% endif %}>Jules</a>
         </li>
       </ul>
       <ul class="navbar-nav ml-auto" id="auth-nav-container">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,9 +3,11 @@ layout: default
 ---
 <article>
 
+  {% unless page.hide_title %}
   <header>
     <h1>{{ page.title | escape }}</h1>
   </header>
+  {% endunless %}
 
   <section>
     {{ content }}

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Jules Panel
+hide_title: true
 permalink: /jules-panel/
 ---
 


### PR DESCRIPTION
This change removes the duplicate title on the Jules Panel page by adding a hide_title frontmatter flag and a corresponding guard in the page layout. It also updates the navbar to show the Jules link as active and non-clickable when the user is already on the Jules Panel page.

---
*PR created automatically by Jules for task [2850102889372757238](https://jules.google.com/task/2850102889372757238) started by @Axlfc*