### PR TITLE
Fix active nav link highlight for Comandos and Tech Stack

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -73,6 +73,7 @@ permalink: /CHANGELOG.html
               <li>Markdown rendering in <code>progressUpdated</code> and <code>sessionCompleted</code> activities in Jules Panel.</li>
               <li>Removed duplicate "Jules Panel" title rendered by the Jekyll layout.</li>
               <li>Applied active state and disabled link for "Jules" in the navbar when on the Jules Panel page.</li>
+              <li>Active state highlighting for "Comandos" and "Tech Stack" links in the main navigation.</li>
             </ul>
             <h5 class="text-danger">Removed</h5>
             <ul class="tree-view mb-0">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,11 +28,11 @@
             <i class="fas fa-tachometer-alt fa-sm fa-fw mr-1 text-purple"></i> Dashboard
           </a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/guia-comandos/' | relative_url }}">Comandos</a>
+        <li class="nav-item {% if page.url == '/guia-comandos/' %}active{% endif %}">
+          <a class="nav-link" href="{{ '/guia-comandos/' | relative_url }}" {% if page.url == '/guia-comandos/' %}style="pointer-events: none; opacity: 0.5;"{% endif %}>Comandos</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/tech-stack/' | relative_url }}">Tech Stack</a>
+        <li class="nav-item {% if page.url == '/tech-stack/' %}active{% endif %}">
+          <a class="nav-link" href="{{ '/tech-stack/' | relative_url }}" {% if page.url == '/tech-stack/' %}style="pointer-events: none; opacity: 0.5;"{% endif %}>Tech Stack</a>
         </li>
         <li class="nav-item {% if page.url == '/jules-panel/' %}active{% endif %}">
           <a class="nav-link" href="{{ '/jules-panel/' | relative_url }}" {% if page.url == '/jules-panel/' %}style="pointer-events: none; opacity: 0.5;"{% endif %}>Jules</a>


### PR DESCRIPTION
This PR fixes the missing active state highlighting for the "Comandos" and "Tech Stack" links in the site navigation. The implementation matches the existing pattern used for the "Jules" link, ensuring consistency across the navbar.

Key changes:
- Modified `_includes/header.html` to add `{% if page.url == '...' %}active{% endif %}` to the `nav-item` list elements.
- Applied conditional styling to the `nav-link` anchors to disable pointer events and reduce opacity when active.
- Verified that both desktop and mobile views share the same logic.

---
*PR created automatically by Jules for task [15502206975044853564](https://jules.google.com/task/15502206975044853564) started by @Axlfc*