### PR TITLE
Kanban Global Toggle Button

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -68,6 +68,7 @@ permalink: /CHANGELOG.html
               <li>TortoiseSVN onboarding section and collaborative workflow guide in <code>guia-ue5-svn.html</code></li>
               <li><code>plan_de_arranque.html</code> unified with platform design system</li>
               <li>CHANGELOG enforcement GitHub Action</li>
+              <li>Botón de toggle inteligente en el Kanban de Operaciones para expandir o contraer todas las tareas de forma global, con persistencia en el navegador.</li>
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -258,6 +258,16 @@ function renderMemberToggles() {
 function renderKanbanBoard() {
   const tasks = getFilteredTasks(currentTasks.filter(t => t.estado !== 'Obsolete'));
 
+  // Update Global Toggle Icon
+  const globalToggle = document.getElementById('global-kanban-toggle');
+  if (globalToggle) {
+    const anyExpanded = tasks.some(t => localStorage.getItem(`task_minimized_${t.id}`) !== 'true');
+    const icon = globalToggle.querySelector('i');
+    if (icon) {
+      icon.className = anyExpanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down';
+    }
+  }
+
   for (const col of KANBAN_COLUMNS) {
     const colEl = document.getElementById(`kanban-col-${col.id}`);
     if (!colEl) continue;
@@ -428,6 +438,20 @@ function toggleTaskMinimize(taskId) {
   const key = `task_minimized_${taskId}`;
   const current = localStorage.getItem(key) === 'true';
   localStorage.setItem(key, !current);
+  renderKanbanBoard();
+}
+
+function toggleAllTasks() {
+  const tasks = getFilteredTasks(currentTasks.filter(t => t.estado !== 'Obsolete'));
+  const anyExpanded = tasks.some(t => localStorage.getItem(`task_minimized_${t.id}`) !== 'true');
+
+  // If any expanded -> minimize all. If all minimized -> expand all.
+  const newState = anyExpanded; // if anyExpanded is true, we want to minimize (set to true)
+
+  tasks.forEach(t => {
+    localStorage.setItem(`task_minimized_${t.id}`, newState);
+  });
+
   renderKanbanBoard();
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -99,9 +99,14 @@
                 <h2 class="text-xl font-bold flex items-center gap-2">
                     <i class="fa-solid fa-table-columns text-emerald-400"></i> Kanban de Operaciones
                 </h2>
-                <button onclick="openCreateTaskModal()" class="bg-emerald-500 hover:bg-emerald-600 text-slate-950 font-bold py-2 px-4 rounded-lg text-sm transition-all flex items-center gap-2">
-                    <i class="fa-solid fa-plus"></i> Nueva Tarea
-                </button>
+                <div class="flex items-center gap-2">
+                    <button id="global-kanban-toggle" onclick="toggleAllTasks()" class="bg-slate-800 hover:bg-slate-700 text-slate-300 font-bold py-2 px-3 rounded-lg text-sm transition-all flex items-center gap-2" title="Contraer/Expandir todas las tareas">
+                        <i class="fa-solid fa-chevron-up"></i>
+                    </button>
+                    <button onclick="openCreateTaskModal()" class="bg-emerald-500 hover:bg-emerald-600 text-slate-950 font-bold py-2 px-4 rounded-lg text-sm transition-all flex items-center gap-2">
+                        <i class="fa-solid fa-plus"></i> Nueva Tarea
+                    </button>
+                </div>
             </div>
             <div id="kanban-board" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <!-- Columns -->


### PR DESCRIPTION
I have added a global toggle button to the operations dashboard Kanban board. This button allows users to expand or collapse all tasks simultaneously.

Key features:
- **Intelligent Logic**: If there's a mix of expanded and collapsed tasks, the first click will collapse everything (clearing the view). If everything is already collapsed, it will expand everything.
- **Dynamic Icon**: The button icon (chevron-up/down) changes based on the current state of the board.
- **Persistence**: The state of each task is saved in the browser's `localStorage`, maintaining the user's preference across sessions.
- **Styling**: Integrated seamlessly with the existing dark-themed Tailwind UI.

---
*PR created automatically by Jules for task [53764053968414666](https://jules.google.com/task/53764053968414666) started by @Axlfc*