### PR TITLE
Fix mobile overflow & improve mobile layout for dashboard and Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -74,6 +74,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li>Responsive layout and horizontal overflow issues on mobile (320px-430px) for Dashboard and Jules Panel.</li>
               <li>Markdown rendering in <code>progressUpdated</code> and <code>sessionCompleted</code> activities in Jules Panel.</li>
               <li>Removed duplicate "Jules Panel" title rendered by the Jekyll layout.</li>
               <li>Applied active state and disabled link for "Jules" in the navbar when on the Jules Panel page.</li>

--- a/_sass/_dashboard.scss
+++ b/_sass/_dashboard.scss
@@ -21,8 +21,16 @@ $dashboard-danger: #ff5555;  // Dracula Red
     gap: 1rem;
     min-height: 70vh;
 
+    @media (max-width: 768px) {
+        flex-direction: column;
+        overflow-x: hidden;
+    }
+
     .kanban-column {
         flex: 0 0 300px;
+        @media (max-width: 768px) {
+            flex: 1 1 auto;
+        }
         background-color: $dashboard-column-bg;
         border: 1px solid $dashboard-border;
         border-radius: 8px;

--- a/_sass/_hypenosys.scss
+++ b/_sass/_hypenosys.scss
@@ -1,6 +1,10 @@
 @charset "utf-8";
 // Hypenosys Custom Styles
 
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 body {
     background-color: $black !important;
     color: $white !important;

--- a/dashboard.html
+++ b/dashboard.html
@@ -26,8 +26,8 @@
 <body class="h-full text-slate-100 flex flex-col">
 
     <!-- Top Navigation / Filter Bar -->
-    <header class="bg-slate-900 border-b border-slate-800 px-6 py-4 flex flex-col md:flex-row justify-between items-center gap-4 sticky top-0 z-40">
-        <div class="flex items-center gap-4">
+    <header class="bg-slate-900 border-b border-slate-800 px-4 md:px-6 py-4 flex flex-col md:flex-row justify-between items-center gap-4 sticky top-0 z-40">
+        <div class="flex flex-col sm:flex-row items-center gap-4 w-full md:w-auto">
             <a href="/" class="text-emerald-400 text-2xl font-bold tracking-tighter flex items-center gap-2">
                 <i class="fa-solid fa-microchip"></i> HYPENOSYS <span class="text-slate-500 font-light text-sm tracking-normal">OPS</span>
             </a>
@@ -37,12 +37,12 @@
                 <a href="#charts" class="text-xs font-bold text-slate-400 hover:text-white transition-all uppercase">Analytics</a>
                 <a href="/tech-stack/" class="text-xs font-bold text-slate-400 hover:text-white transition-all uppercase">Tech Stack</a>
             </div>
-            <div id="member-filters" class="flex items-center gap-2 bg-slate-950 p-1 rounded-lg border border-slate-800">
+            <div id="member-filters" class="flex flex-wrap items-center justify-center gap-2 bg-slate-950 p-1 rounded-lg border border-slate-800">
                 <!-- Member filters injected here -->
             </div>
         </div>
-        <div class="flex items-center gap-6">
-            <div class="flex items-center gap-3 mr-2">
+        <div class="flex flex-wrap items-center justify-center gap-4 md:gap-6">
+            <div class="flex items-center gap-3">
                 <button onclick="window.location.href='/jules-panel/'" class="bg-slate-800 hover:bg-slate-700 text-emerald-400 p-2 rounded-lg transition-all border border-slate-700 flex items-center gap-2 text-xs font-bold" title="Quick Jules">
                     <i class="fa-solid fa-robot"></i> <span class="hidden lg:inline">Quick Jules</span>
                 </button>
@@ -64,7 +64,7 @@
         </div>
 
         <!-- Summary Stats Grid -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div class="grid grid-cols-1 min-[360px]:grid-cols-2 lg:grid-cols-4 gap-6">
             <div class="bg-slate-900 p-5 rounded-2xl border border-slate-800 shadow-sm">
                 <div class="text-slate-500 text-xs font-bold uppercase mb-1">Tareas Activas</div>
                 <div id="stat-total-tasks" class="text-3xl font-bold text-white font-mono">0</div>
@@ -119,7 +119,7 @@
 
         <!-- Kanban Board -->
         <section>
-            <div class="flex items-center justify-between mb-4">
+            <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
                 <h2 class="text-xl font-bold flex items-center gap-2">
                     <i class="fa-solid fa-table-columns text-emerald-400"></i> Kanban de Operaciones
                 </h2>
@@ -175,7 +175,7 @@
             </button>
             <div id="pipeline-content" class="p-6 pt-0 space-y-8">
                 <!-- Pipeline Swimlanes -->
-                <div id="pipeline-swimlanes" class="flex flex-nowrap gap-4 overflow-x-auto pb-4 custom-scrollbar">
+                <div id="pipeline-swimlanes" class="flex flex-col md:flex-row md:flex-nowrap gap-4 md:overflow-x-auto pb-4 custom-scrollbar">
                     <!-- Stages injected here -->
                 </div>
 
@@ -313,7 +313,7 @@
                     <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Descripción</label>
                     <textarea id="task-desc-input" rows="3" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-3 text-slate-100 focus:border-emerald-500 outline-none"></textarea>
                 </div>
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Rama</label>
                         <select id="task-rama-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">
@@ -334,7 +334,7 @@
                         </select>
                     </div>
                 </div>
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Email Responsable</label>
                         <input type="email" id="task-email-responsable-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100 focus:border-emerald-500 outline-none">
@@ -344,7 +344,7 @@
                         <input type="text" id="task-emails-asignados-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100 focus:border-emerald-500 outline-none">
                     </div>
                 </div>
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Milestone</label>
                         <select id="task-milestone-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">
@@ -368,7 +368,7 @@
                         </select>
                     </div>
                 </div>
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Tema Principal (Stage)</label>
                         <select id="task-topic-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">
@@ -387,7 +387,7 @@
                         <input type="number" id="task-completion-input" step="0.1" min="0" max="1" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">
                     </div>
                 </div>
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Resuelto Por</label>
                         <select id="task-resolver-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -227,6 +227,15 @@ permalink: /jules-panel/
     min-height: 100vh;
     font-family: inherit;
     padding: 24px;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+}
+
+@media (max-width: 480px) {
+    .jules-panel-container {
+        padding: 16px;
+    }
 }
 
 .panel-header {
@@ -272,6 +281,7 @@ permalink: /jules-panel/
     display: grid;
     grid-template-columns: 320px 1fr;
     gap: 32px;
+    min-width: 0;
 }
 
 @media (max-width: 1024px) {
@@ -289,6 +299,28 @@ permalink: /jules-panel/
     border: 1px solid var(--border-subtle);
     border-radius: 12px;
     padding: 20px;
+    min-width: 0;
+}
+
+@media (max-width: 375px) {
+    .config-section, .new-session-section {
+        padding: 16px;
+    }
+    .section-title {
+        font-size: 13px;
+        margin-bottom: 12px;
+    }
+    .form-label {
+        font-size: 13px;
+    }
+    .form-select, .form-input, .form-textarea {
+        font-size: 13px;
+        padding: 8px 10px;
+    }
+    .btn--primary {
+        font-size: 12px;
+        padding: 10px 16px;
+    }
 }
 
 /* Common UI Elements */
@@ -482,6 +514,16 @@ permalink: /jules-panel/
     margin-bottom: 12px;
 }
 
+@media (max-width: 350px) {
+    .session-card__meta {
+        flex-direction: column;
+        gap: 4px;
+    }
+    .meta-tag {
+        width: 100%;
+    }
+}
+
 .meta-tag {
     display: inline-flex;
     align-items: center;
@@ -499,6 +541,13 @@ permalink: /jules-panel/
     gap: 8px;
     flex-wrap: wrap;
     margin-bottom: 12px;
+}
+
+@media (max-width: 430px) {
+    .session-card__actions .btn {
+        flex: 1 1 auto;
+        justify-content: center;
+    }
 }
 
 .btn {


### PR DESCRIPTION
This PR fixes multiple horizontal overflow issues and layout clipping on mobile devices for the HypenoSys Ops Dashboard and Jules Panel.

Key changes:
1. **Global Reset:** Standardized `box-sizing: border-box` to prevent padding from causing element overflow.
2. **Dashboard Layout:** 
   - Kanban columns and Pipeline swimlanes now stack vertically on devices <= 768px.
   - Summary stats grid now supports a 2-column layout on screens >= 360px.
   - Header and modal elements adjusted for better stacking on small screens.
3. **Jules Panel:**
   - Sidebar configuration and "New Session" sections now have optimized padding and font sizes (min 13px) for mobile.
   - Session history cards metadata now correctly wraps or stacks on narrow screens (320px).
   - Action buttons expanded for easier touch interaction on mobile.
4. **Verification:** All layouts were verified using Playwright on iPhone SE, iPhone 14, Android Standard, and Narrow Mobile (320px) viewports to ensure zero horizontal scroll.

---
*PR created automatically by Jules for task [10119190357564695572](https://jules.google.com/task/10119190357564695572) started by @Axlfc*