### PR TITLE
Local Repository Aliases for Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -75,6 +75,7 @@ permalink: /CHANGELOG.html
               <li><code>plan_de_arranque.html</code> unified with platform design system</li>
               <li>CHANGELOG enforcement GitHub Action</li>
               <li>Botón de toggle inteligente en el Kanban de Operaciones para expandir o contraer todas las tareas de forma global, con persistencia en el navegador.</li>
+              <li><strong>Alias de Repositorios en Jules Panel:</strong> Implementado sistema para asignar nombres personalizados (alias) a repositorios. Los alias son locales por usuario (<code>localStorage</code>) y no afectan a los datos reales de GitHub, facilitando la identificación de proyectos. Incluye selector con lápiz de edición, modal de configuración y persistencia tras recarga.</li>
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">

--- a/assets/javascript/repo-aliases.js
+++ b/assets/javascript/repo-aliases.js
@@ -1,0 +1,76 @@
+/**
+ * Repository Alias Management for Hypenosys Hub
+ * Persists user-defined aliases in localStorage.
+ */
+
+const REPO_ALIASES_KEY = 'hypenosys_repo_aliases';
+
+/**
+ * Gets all aliases from localStorage.
+ * @returns {Object} Mapping of repoFullName to alias.
+ */
+function _getAllAliases() {
+    try {
+        const stored = localStorage.getItem(REPO_ALIASES_KEY);
+        return stored ? JSON.parse(stored) : {};
+    } catch (e) {
+        console.error('Error reading repo aliases from localStorage:', e);
+        return {};
+    }
+}
+
+/**
+ * Gets the alias for a specific repository.
+ * @param {string} repoFullName - Real repository identifier (e.g., sources/github/owner/repo).
+ * @returns {string|null} The alias or null if not set.
+ */
+function getRepoAlias(repoFullName) {
+    if (!repoFullName) return null;
+    const aliases = _getAllAliases();
+    return aliases[repoFullName] || null;
+}
+
+/**
+ * Sets the alias for a specific repository.
+ * @param {string} repoFullName - Real repository identifier.
+ * @param {string} alias - The new alias.
+ */
+function setRepoAlias(repoFullName, alias) {
+    if (!repoFullName || !alias) return;
+
+    // Validation
+    const cleanAlias = alias.trim().substring(0, 60);
+    if (!cleanAlias) return;
+
+    const aliases = _getAllAliases();
+    aliases[repoFullName] = cleanAlias;
+    localStorage.setItem(REPO_ALIASES_KEY, JSON.stringify(aliases));
+}
+
+/**
+ * Removes the alias for a specific repository.
+ * @param {string} repoFullName - Real repository identifier.
+ */
+function removeRepoAlias(repoFullName) {
+    if (!repoFullName) return;
+    const aliases = _getAllAliases();
+    delete aliases[repoFullName];
+    localStorage.setItem(REPO_ALIASES_KEY, JSON.stringify(aliases));
+}
+
+/**
+ * Gets the display name for a repository (alias if exists, otherwise original name).
+ * @param {string} repoFullName - Real repository identifier.
+ * @param {string} originalName - Original name to fallback to.
+ * @returns {string} The name to display.
+ */
+function getRepoDisplayName(repoFullName, originalName) {
+    const alias = getRepoAlias(repoFullName);
+    return alias || originalName || repoFullName;
+}
+
+// Expose to window
+window.getRepoAlias = getRepoAlias;
+window.setRepoAlias = setRepoAlias;
+window.removeRepoAlias = removeRepoAlias;
+window.getRepoDisplayName = getRepoDisplayName;

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -52,11 +52,18 @@ permalink: /jules-panel/
 
                 <div class="form-group">
                     <label class="form-label">Repositorio</label>
-                    <div class="select-wrapper">
-                        <select id="jules-repo-select" class="form-select">
-                            <option value="">Cargando fuentes...</option>
-                        </select>
-                        <i class="fa-solid fa-chevron-down select-icon"></i>
+                    <div id="jules-repo-real-name" style="font-size: 10px; color: var(--text-muted); font-family: monospace; margin-bottom: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: none;" title="Nombre real del repositorio"></div>
+                    <div style="display: flex; align-items: center; gap: 8px;">
+                        <div class="select-wrapper" style="flex: 1; min-width: 0;">
+                            <select id="jules-repo-select" class="form-select" style="min-height: 42px; width: 100%;">
+                                <option value="">Cargando fuentes...</option>
+                            </select>
+                            <i class="fa-solid fa-chevron-down select-icon"></i>
+                        </div>
+                        <button id="jules-edit-repo-alias-btn" title="Editar nombre local del repositorio"
+                                style="display: none; height: 42px; width: 42px; min-width: 42px; background: transparent; border: 1px solid var(--border-subtle); border-radius: 8px; color: var(--text-secondary); cursor: pointer; transition: all 0.15s ease; align-items: center; justify-content: center;">
+                            <i class="fa-solid fa-pencil"></i>
+                        </button>
                     </div>
                 </div>
 
@@ -184,6 +191,32 @@ permalink: /jules-panel/
                 </div>
             </div>
         </main>
+    </div>
+</div>
+
+<!-- Repo Alias Modal -->
+<div id="repo-alias-modal" class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4">
+    <div class="bg-slate-900 border border-purple-500/30 rounded-2xl shadow-2xl w-full max-w-md p-6">
+        <h3 class="text-xl font-bold text-white mb-2">Editar Alias Local</h3>
+        <p class="text-slate-400 text-[10px] uppercase tracking-widest mb-6">Este nombre solo será visible para ti</p>
+
+        <div class="form-group">
+            <label class="form-label">Nombre Real</label>
+            <div id="alias-modal-real-name" class="text-xs font-mono text-slate-500 bg-slate-950 p-3 rounded-lg border border-slate-800 break-all"></div>
+        </div>
+
+        <div class="form-group">
+            <label class="form-label">Alias del Repositorio</label>
+            <input type="text" id="alias-modal-input" class="form-input" placeholder="Ej: Centro Neural" maxlength="60">
+        </div>
+
+        <div class="flex flex-col gap-3 mt-8">
+            <div class="flex gap-3">
+                <button id="alias-modal-cancel-btn" class="flex-grow py-3 border border-slate-700 hover:bg-slate-800 rounded-lg font-bold text-sm transition-all">Cancelar</button>
+                <button id="alias-modal-save-btn" class="flex-grow py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-bold text-sm transition-all">Guardar</button>
+            </div>
+            <button id="alias-modal-restore-btn" class="w-full py-2 text-slate-500 hover:text-slate-300 text-[10px] font-bold uppercase tracking-widest transition-all">Restaurar nombre original</button>
+        </div>
     </div>
 </div>
 
@@ -961,6 +994,7 @@ permalink: /jules-panel/
 
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="{{ '/assets/javascript/jules-api.js' | relative_url }}"></script>
+<script src="{{ '/assets/javascript/repo-aliases.js' | relative_url }}"></script>
 <script>
     // --- STATE ---
     let currentSources = [];
@@ -1059,8 +1093,9 @@ permalink: /jules-panel/
                 srcs.forEach(s => {
                     const opt = document.createElement('option');
                     opt.value = s.name;
-                    const repo = s.githubRepo?.repo || window.parseSourceName(s.name)?.repo || s.name;
-                    opt.textContent = `${owner}/${repo}`;
+                    const repoShortName = s.githubRepo?.repo || window.parseSourceName(s.name)?.repo || s.name;
+                    const fullRepoLabel = `${owner}/${repoShortName}`;
+                    opt.textContent = window.getRepoDisplayName(s.name, fullRepoLabel);
                     optgroup.appendChild(opt);
                 });
                 repoSelect.appendChild(optgroup);
@@ -1093,12 +1128,21 @@ permalink: /jules-panel/
       const branchSelect  = document.getElementById('jules-branch-input');
       const branchLoading = document.getElementById('jules-branch-loading');
       const branchStatus  = document.getElementById('jules-branch-status');
+      const realNameEl    = document.getElementById('jules-repo-real-name');
+      const editBtn       = document.getElementById('jules-edit-repo-alias-btn');
 
       if (!sourceName) {
         branchSelect.innerHTML = '<option value="">Selecciona una rama...</option>';
         branchStatus.textContent = '';
+        realNameEl.style.display = 'none';
+        editBtn.style.display = 'none';
         return;
       }
+
+      // Mostrar nombre real y habilitar lápiz
+      realNameEl.textContent = sourceName;
+      realNameEl.style.display = 'block';
+      editBtn.style.display = 'flex';
 
       // Estado: cargando
       branchLoading.style.display = 'block';
@@ -1154,6 +1198,55 @@ permalink: /jules-panel/
       .addEventListener('change', function() {
         if (this.value) localStorage.setItem('jules_selected_branch', this.value);
       });
+
+    // --- REPO ALIAS MODAL LOGIC ---
+    const aliasModal = document.getElementById('repo-alias-modal');
+    const aliasInput = document.getElementById('alias-modal-input');
+    const aliasRealName = document.getElementById('alias-modal-real-name');
+
+    document.getElementById('jules-edit-repo-alias-btn').onclick = () => {
+        const repoSelect = document.getElementById('jules-repo-select');
+        const sourceName = repoSelect.value;
+        if (!sourceName) return;
+
+        aliasRealName.textContent = sourceName;
+        aliasInput.value = window.getRepoAlias(sourceName) || '';
+        aliasModal.classList.remove('hidden');
+        aliasInput.focus();
+    };
+
+    document.getElementById('alias-modal-cancel-btn').onclick = () => {
+        aliasModal.classList.add('hidden');
+    };
+
+    document.getElementById('alias-modal-save-btn').onclick = () => {
+        const repoSelect = document.getElementById('jules-repo-select');
+        const sourceName = repoSelect.value;
+        const alias = aliasInput.value.trim();
+
+        if (!alias) {
+            showToast('El alias no puede estar vacío', 'error');
+            return;
+        }
+
+        window.setRepoAlias(sourceName, alias);
+        aliasModal.classList.add('hidden');
+        showToast('Alias guardado correctamente');
+
+        // Refrescar solo el dropdown para mantener el estado
+        initializeRepoSelector();
+    };
+
+    document.getElementById('alias-modal-restore-btn').onclick = () => {
+        const repoSelect = document.getElementById('jules-repo-select');
+        const sourceName = repoSelect.value;
+
+        window.removeRepoAlias(sourceName);
+        aliasModal.classList.add('hidden');
+        showToast('Nombre original restaurado');
+
+        initializeRepoSelector();
+    };
 
     // --- SESSION ACTIONS ---
     async function launchSession() {


### PR DESCRIPTION
This PR implements a local alias system for repositories in the Jules Panel. 

Key features:
- Users can now click a pencil icon next to the repository selector to set a custom name (alias) for each repository.
- Aliases are stored in `localStorage` (`hypenosys_repo_aliases`), ensuring they are persistent for the user but do not affect GitHub or external data.
- The real repository identifier is always displayed above the selector for reference.
- All internal logic and API calls to Jules and GitHub continue to use the real repository names.
- Includes a themed modal matching the dashboard's aesthetic with options to Save, Cancel, and Restore the original name.
- Input validation: trimmed, non-empty, and limited to 60 characters.
- Sanitized display using `textContent`.

---
*PR created automatically by Jules for task [4315276682746612694](https://jules.google.com/task/4315276682746612694) started by @TopperH4rley*