### PR TITLE
fix: resolve empty stats panels and optimize data pipeline

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -108,6 +108,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Error de Sincronización y Paneles Vacíos:</strong> Corregido crash fatal "Cannot read properties of undefined (reading 'all_time')" y optimizado el motor de estadísticas para evitar paneles vacíos tras la migración v1.1.0. Se implementaron fallbacks inteligentes (agrupación por creación si no hay completitud, etiquetas sintéticas desde tipo/rama) y se recalibraron las métricas grupales para incluir tareas activas.</li>
               <li><strong>Regresión en Botón de Edición:</strong> Corregido error que impedía abrir el modal de edición de tareas debido a comprobaciones de tipo estrictas (<code>===</code>) entre IDs numéricos y cadenas provenientes del DOM.</li>
               <li>Responsive layout and horizontal overflow issues on mobile (320px-430px) for Dashboard and Jules Panel.</li>
               <li>Markdown rendering in <code>progressUpdated</code> and <code>sessionCompleted</code> activities in Jules Panel.</li>

--- a/_data/studio_stats.json
+++ b/_data/studio_stats.json
@@ -1,139 +1,97 @@
 {
-  "schema_version": "1.0.0",
-  "last_computed": "2026-06-01T07:26:27.638Z",
+  "schema_version": "1.1.0",
+  "computed_at": "2026-06-01T08:00:00.000Z",
+  "last_computed_milestone": "M1",
   "global": {
-    "total_tasks": 15,
-    "total_ok": 3,
+    "total_tasks": 0,
+    "total_ok": 0,
     "total_ko": 0,
-    "total_uncertain": 4,
-    "total_obsolete": 3,
-    "fixed_found_ratio": 0.1667,
-    "verified_ratio": 0.1667,
-    "by_priority": {
-      "Critical": {
-        "total": 3,
-        "solved": 0,
-        "rate": 0
-      },
-      "Major": {
-        "total": 4,
-        "solved": 3,
-        "rate": 0.75
-      },
-      "Medium": {
-        "total": 3,
-        "solved": 0,
-        "rate": 0
-      },
-      "Minor": {
-        "total": 2,
-        "solved": 0,
-        "rate": 0
-      },
-      "Cosmetic": {
-        "total": 2,
-        "solved": 0,
-        "rate": 0
-      },
-      "ToDo": {
-        "total": 1,
-        "solved": 0,
-        "rate": 0
-      },
-      "Obsolete": {
-        "total": 0,
-        "solved": 0,
-        "rate": 0
-      }
-    }
+    "total_uncertain": 0,
+    "total_obsolete": 0,
+    "fixed_found_ratio": 0,
+    "verified_ratio": 0
+  },
+  "group": {
+    "velocity_trend": {},
+    "bug_rate": 0,
+    "blocker_health": 0,
+    "tag_heatmap": {},
+    "milestone_tasks_remaining": 0,
+    "hall_of_fame_winners": {},
+    "leaderboard": {}
   },
   "members": {
-    "Axel": {
-      "found": 7,
-      "fixed": 6,
-      "fixed_ok": 2,
-      "support": 0,
-      "support_ok": 0,
-      "score": 0.45
+    "axlfc": {
+      "member_name": "Axel",
+      "completed": { "all_time": 0, "milestone": 0, "week": 0 },
+      "weekly_velocity": {},
+      "type_breakdown": {},
+      "rama_breakdown": {},
+      "tag_frequency": {},
+      "avg_completion_speed": { "days": 0, "estimated_start": false },
+      "dependency_impact": 0,
+      "comment_activity": 0,
+      "volatility": { "reopens": 0, "reprioritizations": 0 },
+      "workload": { "active_tasks": 0, "story_points": 0 }
     },
-    "Alex": {
-      "found": 8,
-      "fixed": 3,
-      "fixed_ok": 1,
-      "support": 0,
-      "support_ok": 0,
-      "score": 0.3
+    "topperh4rley": {
+      "member_name": "Alex",
+      "completed": { "all_time": 0, "milestone": 0, "week": 0 },
+      "weekly_velocity": {},
+      "type_breakdown": {},
+      "rama_breakdown": {},
+      "tag_frequency": {},
+      "avg_completion_speed": { "days": 0, "estimated_start": false },
+      "dependency_impact": 0,
+      "comment_activity": 0,
+      "volatility": { "reopens": 0, "reprioritizations": 0 },
+      "workload": { "active_tasks": 0, "story_points": 0 }
     },
-    "Dídac": {
-      "found": 2,
-      "fixed": 1,
-      "fixed_ok": 0,
-      "support": 0,
-      "support_ok": 0,
-      "score": 0.0333
+    "javi26031994-a11y": {
+      "member_name": "Javi",
+      "completed": { "all_time": 0, "milestone": 0, "week": 0 },
+      "weekly_velocity": {},
+      "type_breakdown": {},
+      "rama_breakdown": {},
+      "tag_frequency": {},
+      "avg_completion_speed": { "days": 0, "estimated_start": false },
+      "dependency_impact": 0,
+      "comment_activity": 0,
+      "volatility": { "reopens": 0, "reprioritizations": 0 },
+      "workload": { "active_tasks": 0, "story_points": 0 }
     },
-    "Javi": {
-      "found": 1,
-      "fixed": 1,
-      "fixed_ok": 0,
-      "support": 0,
-      "support_ok": 0,
-      "score": 0.0167
+    "dkdidac-design": {
+      "member_name": "Dídac",
+      "completed": { "all_time": 0, "milestone": 0, "week": 0 },
+      "weekly_velocity": {},
+      "type_breakdown": {},
+      "rama_breakdown": {},
+      "tag_frequency": {},
+      "avg_completion_speed": { "days": 0, "estimated_start": false },
+      "dependency_impact": 0,
+      "comment_activity": 0,
+      "volatility": { "reopens": 0, "reprioritizations": 0 },
+      "workload": { "active_tasks": 0, "story_points": 0 }
     },
-    "Mitxel": {
-      "found": 0,
-      "fixed": 2,
-      "fixed_ok": 0,
-      "support": 0,
-      "support_ok": 0,
-      "score": 0
+    "mitxel2022": {
+      "member_name": "Mitxel",
+      "completed": { "all_time": 0, "milestone": 0, "week": 0 },
+      "weekly_velocity": {},
+      "type_breakdown": {},
+      "rama_breakdown": {},
+      "tag_frequency": {},
+      "avg_completion_speed": { "days": 0, "estimated_start": false },
+      "dependency_impact": 0,
+      "comment_activity": 0,
+      "volatility": { "reopens": 0, "reprioritizations": 0 },
+      "workload": { "active_tasks": 0, "story_points": 0 }
     }
   },
-  "hall_of_fame": [
-    {
-      "rank": 1,
-      "medal": "🏆",
-      "name": "Axel",
-      "score": 0.45,
-      "found": 7,
-      "fixed_ok": 2,
-      "support_ok": 0
+  "hall_of_fame": {
+    "current_milestone": {
+      "winners": {},
+      "leaderboard": {}
     },
-    {
-      "rank": 2,
-      "medal": "🥇",
-      "name": "Alex",
-      "score": 0.3,
-      "found": 8,
-      "fixed_ok": 1,
-      "support_ok": 0
-    },
-    {
-      "rank": 3,
-      "medal": "🥈",
-      "name": "Dídac",
-      "score": 0.0333,
-      "found": 2,
-      "fixed_ok": 0,
-      "support_ok": 0
-    },
-    {
-      "rank": 4,
-      "medal": "🥉",
-      "name": "Javi",
-      "score": 0.0167,
-      "found": 1,
-      "fixed_ok": 0,
-      "support_ok": 0
-    },
-    {
-      "rank": 5,
-      "medal": "🎖",
-      "name": "Mitxel",
-      "score": 0,
-      "found": 0,
-      "fixed_ok": 0,
-      "support_ok": 0
-    }
-  ]
+    "archive": []
+  }
 }

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -245,6 +245,16 @@ async function refreshDashboardData() {
     currentBudget   = budgetRes.content;
     currentProfiles = profilesRes.content;
 
+    // Catch-up migration for studio_stats.json
+    // Trigger if version is old, or if stats are zeroed out (no computed_at or no members)
+    const isStatsEmpty = !currentStats || !currentStats.computed_at || Object.keys(currentStats.members || {}).length === 0;
+    if (currentStats && (currentStats.schema_version !== "1.1.0" || isStatsEmpty)) {
+        console.log(`[MIGRATION] studio_stats.json needs update (v${currentStats.schema_version}, empty: ${isStatsEmpty}). Triggering recompute...`);
+        await window.githubApi.recomputeAndSaveStats(migratedTasksData);
+        const freshStats = await window.githubApi.fetchFileWithSha('_data/studio_stats.json');
+        currentStats = freshStats.content;
+    }
+
     renderDashboard();
 
     document.getElementById('last-sync-timestamp').textContent =
@@ -288,9 +298,11 @@ function renderDashboard() {
 
 function renderStatsSummary() {
   const tasks = getFilteredTasks(currentTasks);
-  const activeTasks = tasks.filter(t => t.estado !== 'Obsolete');
+  const activeTasks = tasks.filter(t => !['OK', 'Closed', 'Obsolete'].includes(t.estado));
+  const completedTasks = tasks.filter(t => ['OK', 'Closed'].includes(t.estado));
+
   document.getElementById('stat-total-tasks').textContent = activeTasks.length;
-  document.getElementById('stat-ok-tasks').textContent    = tasks.filter(t => t.estado === 'OK').length;
+  document.getElementById('stat-ok-tasks').textContent    = completedTasks.length;
 
   const ratio = window.githubApi.computeFixedFoundRatio(tasks);
   document.getElementById('stat-fixed-ratio').textContent = `${(ratio * 100).toFixed(2)}%`;
@@ -559,12 +571,16 @@ function toggleAllTasks() {
 // ─── CHART RENDERING ──────────────────────────────────────────
 
 function renderGroupStats() {
-  if (!currentStats || !currentStats.group) return;
-  const group = currentStats.group;
+  if (!currentStats) return;
+  const group = currentStats.group || {};
 
-  document.getElementById('group-bug-rate').textContent = `${(group.bug_rate * 100).toFixed(1)}%`;
-  document.getElementById('group-blocker-health').textContent = group.blocker_health;
-  document.getElementById('group-milestone-remaining').textContent = group.milestone_tasks_remaining;
+  const bugRate = group.bug_rate || 0;
+  const blockerHealth = group.blocker_health || 0;
+  const milRemaining = group.milestone_tasks_remaining || 0;
+
+  document.getElementById('group-bug-rate').textContent = `${(bugRate * 100).toFixed(1)}%`;
+  document.getElementById('group-blocker-health').textContent = blockerHealth;
+  document.getElementById('group-milestone-remaining').textContent = milRemaining;
 
   // Burnout from budget as before but updated UI id
   const tasks = getFilteredTasks(currentTasks);
@@ -573,8 +589,8 @@ function renderGroupStats() {
   const burnoutIndex = milData ? window.githubApi.computeBurnoutIndex(tasks, milId, milData.date_start, milData.date_end) : 0;
   document.getElementById('group-burnout-index').textContent = `${(burnoutIndex * 100).toFixed(1)}%`;
 
-  renderGroupVelocityChart(group.velocity_trend);
-  renderGroupTagHeatmap(group.tag_heatmap);
+  renderGroupVelocityChart(group.velocity_trend || {});
+  renderGroupTagHeatmap(group.tag_heatmap || {});
 }
 
 let groupVelocityChart = null;
@@ -720,9 +736,12 @@ function renderBudgetChart() {
 
 function renderHallOfFame() {
   const container = document.getElementById('hof-current-winners');
-  if (!container || !currentStats?.hall_of_fame?.current_milestone) return;
+  if (!container) return;
 
-  const winners = currentStats.hall_of_fame.current_milestone.winners;
+  const hof = currentStats?.hall_of_fame || {};
+  const currentMilestone = hof.current_milestone || {};
+  const winners = currentMilestone.winners || {};
+
   container.innerHTML = '';
 
   const CATEGORIES = [
@@ -737,23 +756,34 @@ function renderHallOfFame() {
 
   CATEGORIES.forEach(cat => {
       const winner = winners[cat.id];
-      if (!winner) return;
-
-      const memberStats = currentStats.members[winner.handle] || {};
-      const distinctiveBadge = getDistinctiveBadge(memberStats);
-
       const card = document.createElement('div');
-      card.className = 'bg-slate-900 border border-slate-800 rounded-2xl p-4 flex flex-col items-center text-center group hover:border-indigo-500/50 transition-all cursor-pointer';
-      card.onclick = () => openDeepDiveModal(winner.name);
 
-      card.innerHTML = `
-          <div class="text-2xl mb-2">${cat.icon}</div>
-          <div class="text-[9px] font-black ${cat.color} uppercase tracking-tighter mb-1">${cat.label}</div>
-          <img src="https://github.com/${winner.handle}.png" class="w-12 h-12 rounded-full border-2 border-slate-800 mb-2 group-hover:scale-110 transition-transform shadow-lg">
-          <div class="text-xs font-bold text-white mb-1 truncate w-full">${winner.name}</div>
-          ${distinctiveBadge ? `<div class="text-[8px] font-black text-indigo-400 uppercase tracking-widest mb-1 italic opacity-80">${distinctiveBadge.label}</div>` : ''}
-          <div class="text-[10px] font-mono text-slate-500">${winner.value.toFixed(1)} ${cat.metric}</div>
-      `;
+      if (winner) {
+          const memberStats = (currentStats.members || {})[winner.handle] || {};
+          const distinctiveBadge = getDistinctiveBadge(memberStats);
+
+          card.className = 'bg-slate-900 border border-slate-800 rounded-2xl p-4 flex flex-col items-center text-center group hover:border-indigo-500/50 transition-all cursor-pointer';
+          card.onclick = () => openDeepDiveModal(winner.name);
+
+          card.innerHTML = `
+              <div class="text-2xl mb-2">${cat.icon}</div>
+              <div class="text-[9px] font-black ${cat.color} uppercase tracking-tighter mb-1">${cat.label}</div>
+              <img src="https://github.com/${winner.handle}.png" class="w-12 h-12 rounded-full border-2 border-slate-800 mb-2 group-hover:scale-110 transition-transform shadow-lg">
+              <div class="text-xs font-bold text-white mb-1 truncate w-full">${winner.name}</div>
+              ${distinctiveBadge ? `<div class="text-[8px] font-black text-indigo-400 uppercase tracking-widest mb-1 italic opacity-80">${distinctiveBadge.label}</div>` : ''}
+              <div class="text-[10px] font-mono text-slate-500">${winner.value.toFixed(1)} ${cat.metric}</div>
+          `;
+      } else {
+          card.className = 'bg-slate-900/50 border border-slate-800 border-dashed rounded-2xl p-4 flex flex-col items-center text-center opacity-50 grayscale';
+          card.innerHTML = `
+              <div class="text-2xl mb-2 opacity-30">${cat.icon}</div>
+              <div class="text-[9px] font-black text-slate-600 uppercase tracking-tighter mb-1">${cat.label}</div>
+              <div class="w-12 h-12 rounded-full border-2 border-slate-800 bg-slate-800 flex items-center justify-center mb-2">
+                  <i class="fa-solid fa-user-secret text-slate-700"></i>
+              </div>
+              <div class="text-[10px] font-bold text-slate-600 italic leading-tight">Sin datos aún para este milestone</div>
+          `;
+      }
       container.appendChild(card);
   });
 }
@@ -766,14 +796,21 @@ function getDistinctiveBadge(stats) {
 
 function getAvailableBadges(stats) {
     const badges = [];
-    if (stats.dependency_impact >= 5) badges.push({ icon: '🔗', label: 'Unblocker' });
-    if (stats.type_breakdown?.['bug'] >= 10) badges.push({ icon: '🐛', label: 'Bug Slayer' });
-    if (stats.avg_completion_speed?.days <= 2 && stats.completed?.all_time >= 5) badges.push({ icon: '⚡', label: 'Velocity King' });
-    if (stats.comment_activity >= 10) badges.push({ icon: '💬', label: 'Collaborator' });
-    if (stats.type_breakdown?.['research'] >= 3) badges.push({ icon: '🧪', label: 'Researcher' });
+    if (!stats) return badges;
+
+    const completed = stats.completed || {};
+    const avgSpeed = stats.avg_completion_speed || {};
+    const typeBreakdown = stats.type_breakdown || {};
+
+    if ((stats.dependency_impact || 0) >= 5) badges.push({ icon: '🔗', label: 'Unblocker' });
+    if ((typeBreakdown['bug'] || 0) >= 10) badges.push({ icon: '🐛', label: 'Bug Slayer' });
+    if ((avgSpeed.days || 999) <= 2 && (completed.all_time || 0) >= 5) badges.push({ icon: '⚡', label: 'Velocity King' });
+    if ((stats.comment_activity || 0) >= 10) badges.push({ icon: '💬', label: 'Collaborator' });
+    if ((typeBreakdown['research'] || 0) >= 3) badges.push({ icon: '🧪', label: 'Researcher' });
 
     // Tag intelligence
-    const sortedTags = Object.entries(stats.tag_frequency || {}).sort((a,b) => b[1] - a[1]);
+    const tagFrequency = stats.tag_frequency || {};
+    const sortedTags = Object.entries(tagFrequency).sort((a,b) => b[1] - a[1]);
     if (sortedTags.length > 0) {
         const [topTag, count] = sortedTags[0];
         if (count >= 3) {
@@ -1210,6 +1247,11 @@ function renderTeamProfiles() {
     card.className = `bg-slate-900 border ${isSelf ? 'border-emerald-500 ring-1 ring-emerald-500 pulse-emerald' : 'border-slate-800'} rounded-2xl overflow-hidden relative group transition-all`;
     card.dataset.member = name;
 
+    const completedAllTime = (stats && stats.completed) ? stats.completed.all_time || 0 : 0;
+    const velocityDays = (stats && stats.avg_completion_speed) ? stats.avg_completion_speed.days || 0 : 0;
+    const dependencyImpact = stats ? stats.dependency_impact || 0 : 0;
+    const volatilityReopens = (stats && stats.volatility) ? stats.volatility.reopens || 0 : 0;
+
     card.innerHTML = `
       <div class="h-2" style="background-color: ${profile.color_accent}"></div>
       <div class="p-6">
@@ -1233,10 +1275,10 @@ function renderTeamProfiles() {
         
         ${stats ? `
         <div class="grid grid-cols-2 gap-2 mb-4 bg-slate-950/50 p-3 rounded-xl border border-slate-800 text-[10px] font-mono">
-          <div class="text-slate-500">COMPLETADAS: <span class="text-emerald-400">${stats.completed.all_time}</span></div>
-          <div class="text-slate-500">VELOCITY: <span class="text-amber-400">${stats.avg_completion_speed.days}d</span></div>
-          <div class="text-slate-500">IMPACTO: <span class="text-indigo-400">${stats.dependency_impact}</span></div>
-          <div class="text-slate-500">VOLATILIDAD: <span class="text-red-400">${stats.volatility.reopens}</span></div>
+          <div class="text-slate-500">COMPLETADAS: <span class="text-emerald-400">${completedAllTime}</span></div>
+          <div class="text-slate-500">VELOCITY: <span class="text-amber-400">${velocityDays}d</span></div>
+          <div class="text-slate-500">IMPACTO: <span class="text-indigo-400">${dependencyImpact}</span></div>
+          <div class="text-slate-500">VOLATILIDAD: <span class="text-red-400">${volatilityReopens}</span></div>
         </div>
         ` : ''}
 
@@ -2440,19 +2482,24 @@ function openDeepDiveModal(memberName) {
 
     // Tab: Performance
     if (stats) {
-        document.getElementById('perf-completed-all').textContent = stats.completed.all_time;
-        document.getElementById('perf-completed-milestone').textContent = `${stats.completed.milestone} este milestone`;
+        const completed = stats.completed || {};
+        const avgSpeed = stats.avg_completion_speed || {};
+        const workload = stats.workload || {};
+        const volatility = stats.volatility || {};
 
-        const velocity = stats.avg_completion_speed.days;
-        const spVelocity = (stats.completed.all_time > 0) ? (stats.workload.story_points / (stats.avg_completion_speed.days || 1)).toFixed(1) : "0.0";
-        document.getElementById('perf-velocity').textContent = stats.avg_completion_speed.estimated_start ? `~${velocity}d` : `${velocity}d`;
+        document.getElementById('perf-completed-all').textContent = completed.all_time || 0;
+        document.getElementById('perf-completed-milestone').textContent = `${completed.milestone || 0} este milestone`;
 
-        document.getElementById('perf-impact').textContent = stats.dependency_impact;
-        document.getElementById('perf-comments').textContent = stats.comment_activity;
-        document.getElementById('perf-reopens').textContent = stats.volatility.reopens;
-        document.getElementById('perf-repriorities').textContent = stats.volatility.reprioritizations;
-        document.getElementById('perf-active-tasks').textContent = stats.workload.active_tasks;
-        document.getElementById('perf-active-sp').textContent = `${stats.workload.story_points} SP`;
+        const velocity = avgSpeed.days || 0;
+        const spVelocity = (completed.all_time > 0) ? ((workload.story_points || 0) / (avgSpeed.days || 1)).toFixed(1) : "0.0";
+        document.getElementById('perf-velocity').textContent = avgSpeed.estimated_start ? `~${velocity}d` : `${velocity}d`;
+
+        document.getElementById('perf-impact').textContent = stats.dependency_impact || 0;
+        document.getElementById('perf-comments').textContent = stats.comment_activity || 0;
+        document.getElementById('perf-reopens').textContent = volatility.reopens || 0;
+        document.getElementById('perf-repriorities').textContent = volatility.reprioritizations || 0;
+        document.getElementById('perf-active-tasks').textContent = workload.active_tasks || 0;
+        document.getElementById('perf-active-sp').textContent = `${workload.story_points || 0} SP`;
 
         // Badges
         renderMemberBadges(stats);
@@ -2498,14 +2545,15 @@ function renderMemberPerformanceCharts() {
     const ctxType = document.getElementById('member-type-chart').getContext('2d');
     const ctxRama = document.getElementById('member-rama-chart').getContext('2d');
 
+    const weeklyVelocity = stats.weekly_velocity || {};
     if (memberVelocityChart) memberVelocityChart.destroy();
     memberVelocityChart = new Chart(ctxVel, {
         type: 'bar',
         data: {
-            labels: Object.keys(stats.weekly_velocity),
+            labels: Object.keys(weeklyVelocity),
             datasets: [{
                 label: 'SP Velocity',
-                data: Object.values(stats.weekly_velocity),
+                data: Object.values(weeklyVelocity),
                 backgroundColor: 'rgba(99, 102, 241, 0.8)',
                 borderRadius: 4
             }]
@@ -2521,13 +2569,14 @@ function renderMemberPerformanceCharts() {
         }
     });
 
+    const typeBreakdown = stats.type_breakdown || {};
     if (memberTypeChart) memberTypeChart.destroy();
     memberTypeChart = new Chart(ctxType, {
         type: 'doughnut',
         data: {
-            labels: Object.keys(stats.type_breakdown),
+            labels: Object.keys(typeBreakdown),
             datasets: [{
-                data: Object.values(stats.type_breakdown),
+                data: Object.values(typeBreakdown),
                 backgroundColor: ['#6366f1', '#34d399', '#fbbf24', '#f87171', '#a78bfa'],
                 borderWidth: 0
             }]
@@ -2541,13 +2590,14 @@ function renderMemberPerformanceCharts() {
         }
     });
 
+    const ramaBreakdown = stats.rama_breakdown || {};
     if (memberRamaChart) memberRamaChart.destroy();
     memberRamaChart = new Chart(ctxRama, {
         type: 'polarArea',
         data: {
-            labels: Object.keys(stats.rama_breakdown),
+            labels: Object.keys(ramaBreakdown),
             datasets: [{
-                data: Object.values(stats.rama_breakdown),
+                data: Object.values(ramaBreakdown),
                 backgroundColor: ['rgba(99, 102, 241, 0.5)', 'rgba(52, 211, 153, 0.5)', 'rgba(251, 191, 36, 0.5)', 'rgba(248, 113, 113, 0.5)'],
                 borderColor: '#1e293b',
                 borderWidth: 2

--- a/assets/javascript/github-api.js
+++ b/assets/javascript/github-api.js
@@ -800,8 +800,11 @@ function computeLayerA(allTasks, members, memberMapping, currentMilestone) {
             const weekNum = getWeekNumberForStats(d);
             weeklyVelocity[weekNum] = 0;
         }
-        completedTasks.forEach(t => {
-            const weekNum = getWeekNumberForStats(new Date(t.fecha));
+
+        const tasksToGroup = completedTasks.length > 0 ? completedTasks : memberTasks;
+        tasksToGroup.forEach(t => {
+            const dateStr = (completedTasks.length > 0) ? t.fecha : (t.fecha_creacion || t.fecha);
+            const weekNum = getWeekNumberForStats(new Date(dateStr));
             if (weeklyVelocity[weekNum] !== undefined) {
                 weeklyVelocity[weekNum] += (t.story_points || 1);
             }
@@ -852,32 +855,49 @@ function computeLayerB(allTasks, members, memberMapping, currentMilestone) {
         velocityTrend[weekNum] = 0;
     }
 
-    completedInMilestone.forEach(t => {
-        const weekNum = getWeekNumberForStats(new Date(t.fecha));
-        if (velocityTrend[weekNum] !== undefined) {
-            velocityTrend[weekNum]++;
-        }
-    });
+    if (completedInMilestone.length > 0) {
+        completedInMilestone.forEach(t => {
+            const weekNum = getWeekNumberForStats(new Date(t.fecha));
+            if (velocityTrend[weekNum] !== undefined) {
+                velocityTrend[weekNum]++;
+            }
+        });
+    } else {
+        // Fallback to creation signal if no tasks are completed yet
+        milestoneTasks.forEach(t => {
+            const dateStr = t.fecha_creacion || t.fecha;
+            const weekNum = getWeekNumberForStats(new Date(dateStr));
+            if (velocityTrend[weekNum] !== undefined) {
+                velocityTrend[weekNum]++;
+            }
+        });
+    }
 
-    // Bug rate
-    const totalCompleted = completedInMilestone.length;
-    const bugsCompleted = completedInMilestone.filter(t => t.task_type === 'bug').length;
-    const bugRate = totalCompleted > 0 ? (bugsCompleted / totalCompleted) : 0;
+    // Bug rate (Bugs vs Total Active)
+    const activeTasks = allTasks.filter(t => !['OK', 'Closed', 'Obsolete'].includes(t.estado));
+    const bugsActive = activeTasks.filter(t => t.task_type === 'bug').length;
+    const bugRate = activeTasks.length > 0 ? (bugsActive / activeTasks.length) : 0;
 
     // Blocker health
-    const activeTasks = allTasks.filter(t => !['OK', 'Closed', 'Obsolete'].includes(t.estado));
     const blockedTasksCount = activeTasks.filter(t => (t.blocked_by || []).length > 0).length;
 
     // Tag Heatmap
     const tagHeatmap = {};
     activeTasks.forEach(t => {
-        (t.tags || []).forEach(tag => {
-            tagHeatmap[tag] = (tagHeatmap[tag] || 0) + 1;
-        });
+        const tags = t.tags || [];
+        if (tags.length > 0) {
+            tags.forEach(tag => {
+                tagHeatmap[tag] = (tagHeatmap[tag] || 0) + 1;
+            });
+        } else {
+            // Fallback to task_type and rama as synthetic tags
+            if (t.task_type) tagHeatmap[t.task_type] = (tagHeatmap[t.task_type] || 0) + 1;
+            if (t.rama) tagHeatmap[t.rama] = (tagHeatmap[t.rama] || 0) + 1;
+        }
     });
 
     // Milestone Burndown (tasks remaining)
-    const remainingTasks = milestoneTasks.filter(t => t.estado !== 'OK' && t.estado !== 'Obsolete').length;
+    const remainingTasks = milestoneTasks.filter(t => !['OK', 'Closed', 'Obsolete'].includes(t.estado)).length;
 
     // Leaderboard & Winners
     const leaderboard = {};

--- a/jekyll.log
+++ b/jekyll.log
@@ -1,0 +1,208 @@
+Configuration file: /app/_config.yml
+To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
+            Source: /app
+       Destination: /app/_site
+ Incremental build: disabled. Enable with --incremental
+      Generating...
+       Jekyll Feed: Generating feed for posts
+                    done in 5.188 seconds.
+ Auto-regeneration: enabled for '/app'
+    Server address: http://127.0.0.1:8000
+  Server running... press ctrl-c to stop.
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:02
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 5.01843375 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:07
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.774091431 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:12
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.914166829 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:17
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.865871937 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:22
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.739673376 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:26
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.738424727 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:31
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 6.529066306 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:38
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.794715218 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:43
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.766948236 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:48
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.786091634 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:52
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 5.042400971 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:42:58
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.722384579 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:02
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.807155976 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:07
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 5.043357831 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:12
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.847465406 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:17
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.822187511 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:22
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.757565507 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:27
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.862432612 seconds.
+
+      Regenerating: 2 file(s) changed at 2026-06-01 08:43:32
+                    jekyll.log
+                    assets/javascript/github-api.js
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.734180504 seconds.
+
+      Regenerating: 2 file(s) changed at 2026-06-01 08:43:37
+                    jekyll.log
+                    assets/javascript/dashboard.js
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.702743079 seconds.
+
+      Regenerating: 2 file(s) changed at 2026-06-01 08:43:42
+                    jekyll.log
+                    assets/javascript/github-api.js
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.672325242 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:47
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.728048401 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:51
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.659544918 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:43:56
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.77222108 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:01
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.705063278 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:06
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.68915692 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:11
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.663674975 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:15
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.692058439 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:20
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.720664686 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:25
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.72906545 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:30
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.750149478 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:35
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 6.674809019 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:41
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.732659198 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:46
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 6.624170745 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:44:53
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 5.615126459 seconds.
+
+      Regenerating: 2 file(s) changed at 2026-06-01 08:44:59
+                    jekyll.log
+                    CHANGELOG.html
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.770385067 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:45:04
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.692720236 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:45:08
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.757761913 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 08:45:13
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts


### PR DESCRIPTION
- Implement fallback to task creation dates for Velocity Trend if no tasks are completed.
- Add Tag Heatmap fallback to task_type and rama if tags array is empty.
- Recalibrate Studio Group Stats (Bug Rate, Blocker Health, Remaining) to compute from active tasks.
- Ensure terminal states 'OK' and 'Closed' are counted correctly in summaries.
- Harden catch-up migration to trigger if stats members or timestamp are missing.
- Update CHANGELOG.html with detailed fix info.