### PR TITLE
Arreglo de retardo en clic de imágenes y mejora de navegación en Lightbox

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,9 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Retardo en apertura de Lightbox:</strong> Corregido bug donde las fotos de las tareas no se abrían inmediatamente en dispositivos táctiles/tablets. Se implementó <code>event.stopPropagation()</code> y <code>draggable="false"</code> para evitar conflictos con el sistema de arrastre del Kanban.</li>
+              <li><strong>Navegación en Lightbox:</strong> Añadidas flechas de navegación y contador de imágenes para permitir ciclar entre múltiples fotos de una tarea sin cerrar el visor.</li>
+              <li><strong>Soporte de Teclado:</strong> Implementado cierre con Escape y navegación con flechas de dirección en el visor de imágenes.</li>
               <li><strong>Error de Sincronización y Paneles Vacíos:</strong> Corregido crash fatal "Cannot read properties of undefined (reading 'all_time')" y optimizado el motor de estadísticas para evitar paneles vacíos tras la migración v1.1.0. Se implementaron fallbacks inteligentes (agrupación por creación si no hay completitud, etiquetas sintéticas desde tipo/rama) y se recalibraron las métricas grupales para incluir tareas activas.</li>
               <li><strong>Regresión en Botón de Edición:</strong> Corregido error que impedía abrir el modal de edición de tareas debido a comprobaciones de tipo estrictas (<code>===</code>) entre IDs numéricos y cadenas provenientes del DOM.</li>
               <li>Responsive layout and horizontal overflow issues on mobile (320px-430px) for Dashboard and Jules Panel.</li>

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -37,6 +37,11 @@ let currentBudget = null;
 let currentProfiles = null;
 let currentTaskImages = []; // TODO: Migrate to external storage (e.g. GitHub Assets/R2) if JSON size exceeds 10MB
 
+// Lightbox Global State
+let lightboxTask = null;
+let lightboxImages = [];
+let lightboxIndex = 0;
+
 const KANBAN_COLUMNS = [
   { id: 'backlog',    label: 'Backlog / ToDo',        states: ['Pending','ToDo',null],           icon: '📋' },
   { id: 'working',   label: 'En Progreso',             states: ['Working','KO'],                  icon: '⚡' },
@@ -483,8 +488,10 @@ function buildTaskCard(task) {
             ${task.images.map((img, idx) => {
                 const isLegacy = img.type === 'binary_legacy';
                 return `
-                <div class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative" onclick="openLightbox('${task.id}', ${idx})">
-                    <img src="${img.url}" class="w-full h-full object-cover" alt="Task image" loading="lazy">
+                <div class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative"
+                     onclick="event.stopPropagation(); openLightbox('${task.id}', ${idx})"
+                     draggable="false">
+                    <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
                 </div>
             `;}).join('')}
@@ -1310,6 +1317,16 @@ function renderTeamProfiles() {
 // ─── ACTIONS & EVENT HANDLERS ────────────────────────────────
 
 function setupEventListeners() {
+  // Lightbox keyboard support
+  document.addEventListener('keydown', (e) => {
+    const modal = document.getElementById('lightbox-modal');
+    if (modal && !modal.classList.contains('hidden')) {
+        if (e.key === 'Escape') closeLightbox();
+        if (e.key === 'ArrowLeft') navigateLightbox(-1);
+        if (e.key === 'ArrowRight') navigateLightbox(1);
+    }
+  });
+
   const taskCancel = document.getElementById('task-cancel-btn');
   const taskSave = document.getElementById('task-save-btn');
   const qaCancel = document.getElementById('qa-cancel-btn');
@@ -1977,27 +1994,77 @@ function openLightbox(srcOrTaskId, imageIndex) {
     const img = document.getElementById('lightbox-img');
     if (!modal || !img) return;
 
+    // Reset state
+    lightboxTask = null;
+    lightboxImages = [];
+    lightboxIndex = 0;
+
     if (imageIndex === undefined) {
-        // Fallback or direct src (discouraged for large base64)
+        // Fallback or direct src
         img.src = srcOrTaskId;
     } else {
         if (srcOrTaskId === 'current') {
-            if (currentTaskImages[imageIndex]) {
-                img.src = currentTaskImages[imageIndex].url;
-            }
+            lightboxImages = currentTaskImages;
+            lightboxIndex = imageIndex;
         } else {
-            const task = currentTasks.find(t => String(t.id) === String(srcOrTaskId));
-            if (task && task.images && task.images[imageIndex]) {
-                img.src = task.images[imageIndex].url;
+            const task = currentTasks.find(t => sameTaskId(t.id, srcOrTaskId));
+            if (task) {
+                lightboxTask = task;
+                lightboxImages = task.images || [];
+                lightboxIndex = imageIndex;
             }
         }
+
+        if (lightboxImages[lightboxIndex]) {
+            img.src = lightboxImages[lightboxIndex].url;
+        }
     }
+
+    updateLightboxUI();
     modal.classList.remove('hidden');
+}
+
+function updateLightboxUI() {
+    const prevBtn = document.getElementById('lightbox-prev');
+    const nextBtn = document.getElementById('lightbox-next');
+    const counter = document.getElementById('lightbox-counter');
+
+    if (lightboxImages.length > 1) {
+        if (prevBtn) prevBtn.classList.remove('hidden');
+        if (nextBtn) nextBtn.classList.remove('hidden');
+        if (counter) {
+            counter.classList.remove('hidden');
+            counter.textContent = `${lightboxIndex + 1} / ${lightboxImages.length}`;
+        }
+    } else {
+        if (prevBtn) prevBtn.classList.add('hidden');
+        if (nextBtn) nextBtn.classList.add('hidden');
+        if (counter) counter.classList.add('hidden');
+    }
+}
+
+function navigateLightbox(direction) {
+    if (lightboxImages.length <= 1) return;
+
+    lightboxIndex += direction;
+    if (lightboxIndex >= lightboxImages.length) lightboxIndex = 0;
+    if (lightboxIndex < 0) lightboxIndex = lightboxImages.length - 1;
+
+    const img = document.getElementById('lightbox-img');
+    if (img && lightboxImages[lightboxIndex]) {
+        img.src = lightboxImages[lightboxIndex].url;
+        updateLightboxUI();
+    }
 }
 
 function closeLightbox() {
     const modal = document.getElementById('lightbox-modal');
-    if (modal) modal.classList.add('hidden');
+    if (modal) {
+        modal.classList.add('hidden');
+        // Clear src to avoid flicker on next open
+        const img = document.getElementById('lightbox-img');
+        if (img) img.src = "";
+    }
 }
 
 function toggleProfileEdit(memberName) {
@@ -2638,3 +2705,6 @@ function renderMemberBadges(stats) {
 window.openDeepDiveModal = openDeepDiveModal;
 window.closeDeepDiveModal = closeDeepDiveModal;
 window.switchDeepDiveTab = switchDeepDiveTab;
+window.openLightbox = openLightbox;
+window.closeLightbox = closeLightbox;
+window.navigateLightbox = navigateLightbox;

--- a/dashboard.html
+++ b/dashboard.html
@@ -692,10 +692,29 @@
 
     <!-- Lightbox Modal -->
     <div id="lightbox-modal" class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/95 backdrop-blur-md p-4" onclick="closeLightbox()">
-        <button class="absolute top-6 right-6 text-white text-3xl hover:text-emerald-400 transition-colors">
+        <!-- Close Button -->
+        <button onclick="closeLightbox()" class="absolute top-6 right-6 text-white/50 hover:text-white text-4xl transition-all z-[110]">
             <i class="fa-solid fa-xmark"></i>
         </button>
-        <img id="lightbox-img" src="" alt="Vista ampliada" class="max-w-full max-h-full object-contain shadow-2xl rounded-lg" onclick="event.stopPropagation()">
+
+        <!-- Navigation Buttons -->
+        <button id="lightbox-prev" onclick="navigateLightbox(-1); event.stopPropagation();" class="absolute left-4 md:left-8 top-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-slate-900/50 text-white flex items-center justify-center hover:bg-emerald-500 hover:text-slate-950 transition-all z-[110] hidden">
+            <i class="fa-solid fa-chevron-left text-xl"></i>
+        </button>
+
+        <button id="lightbox-next" onclick="navigateLightbox(1); event.stopPropagation();" class="absolute right-4 md:right-8 top-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-slate-900/50 text-white flex items-center justify-center hover:bg-emerald-500 hover:text-slate-950 transition-all z-[110] hidden">
+            <i class="fa-solid fa-chevron-right text-xl"></i>
+        </button>
+
+        <!-- Image Container -->
+        <div class="relative max-w-full max-h-full flex flex-col items-center">
+            <img id="lightbox-img" src="" alt="Vista ampliada" class="max-w-full max-h-[85vh] object-contain shadow-2xl rounded-lg border border-slate-800" onclick="event.stopPropagation()">
+
+            <!-- Counter & Label -->
+            <div id="lightbox-counter" class="mt-4 px-4 py-1.5 bg-slate-900/80 border border-slate-700 rounded-full text-xs font-mono text-slate-300 backdrop-blur-sm hidden">
+                1 / 1
+            </div>
+        </div>
     </div>
 
     <!-- Member Deep Dive Modal -->


### PR DESCRIPTION
Este PR soluciona el bug reportado en el dashboard operacional donde las fotos de las tareas no se abrían inmediatamente al hacer clic (especialmente notable en tablets) y requerían un segundo clic en otra acción para disparar la apertura.

Cambios realizados:
1.  **Dashboard UI (`dashboard.html`)**:
    *   Se han añadido flechas laterales (Anterior/Siguiente) y un contador de imágenes al modal de previsualización (Lightbox).
    *   Mejora en la visibilidad y accesibilidad del botón de cierre.
    *   Ajuste del diseño para que sea totalmente responsivo y se adapte mejor a pantallas táctiles.

2.  **Lógica del Dashboard (`assets/javascript/dashboard.js`)**:
    *   **Solución al Retraso en Touch**: Se ha añadido `event.stopPropagation()` y `draggable="false"` a las miniaturas de las imágenes. Esto evita que el sistema de drag-and-drop del Kanban interfiera con el evento de clic, permitiendo que la previsualización se abra instantáneamente al primer toque.
    *   **Navegación de Imágenes**: Se ha implementado un estado global para rastrear la tarea y la imagen actual, permitiendo ciclar por todas las fotos de una misma tarea sin salir del modal.
    *   **Soporte de Teclado**: Añadido soporte para cerrar con 'Esc' y navegar con las flechas del teclado.
    *   **Exposición Global**: Se han exportado explícitamente las funciones `openLightbox`, `closeLightbox` y `navigateLightbox` al objeto `window` para asegurar su correcto funcionamiento desde los atributos `onclick` del HTML.

Se ha verificado la funcionalidad mediante pruebas automatizadas con Playwright, confirmando que el modal se abre correctamente al primer clic y que la navegación entre múltiples imágenes funciona según lo esperado.

---
*PR created automatically by Jules for task [7627873393682673681](https://jules.google.com/task/7627873393682673681) started by @Axlfc*