### PR TITLE
Bug Follow-up: Lightbox Still Not Opening on First Click

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,14 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Bug Follow-up — Retardo en apertura de Lightbox:</strong> Corregido definitivamente el problema donde las fotos de las tareas requerían dos interacciones para abrirse en dispositivos táctiles.
+                <ul>
+                  <li>Implementado el uso de <code>onpointerdown</code> con <code>event.preventDefault()</code> para interceptar la interacción antes de la separación de eventos de foco/click del navegador.</li>
+                  <li>Migración de contenedores de imágenes a etiquetas semánticas <code>&lt;button&gt;</code> para mejorar la prioridad de eventos y la accesibilidad.</li>
+                  <li>Añadido soporte para teclado (Enter/Espacio) mediante <code>onkeydown</code> para mantener la accesibilidad universal.</li>
+                  <li>Uso de <code>focus-visible</code> para suprimir el anillo de foco en interacciones de puntero mientras se preserva para usuarios de teclado.</li>
+                </ul>
+              </li>
               <li><strong>Retardo en apertura de Lightbox:</strong> Corregido bug donde las fotos de las tareas no se abrían inmediatamente en dispositivos táctiles/tablets. Se implementó <code>event.stopPropagation()</code> y <code>draggable="false"</code> para evitar conflictos con el sistema de arrastre del Kanban.</li>
               <li><strong>Navegación en Lightbox:</strong> Añadidas flechas de navegación y contador de imágenes para permitir ciclar entre múltiples fotos de una tarea sin cerrar el visor.</li>
               <li><strong>Soporte de Teclado:</strong> Implementado cierre con Escape y navegación con flechas de dirección en el visor de imágenes.</li>

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -488,12 +488,12 @@ function buildTaskCard(task) {
             ${task.images.map((img, idx) => {
                 const isLegacy = img.type === 'binary_legacy';
                 return `
-                <div class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative"
-                     onclick="event.stopPropagation(); openLightbox('${task.id}', ${idx})"
+                <button type="button" class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative focus:outline-none focus:border-slate-800"
+                     onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('${task.id}', ${idx})"
                      draggable="false">
                     <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
-                </div>
+                </button>
             `;}).join('')}
         </div>
       </div>
@@ -1968,7 +1968,7 @@ function renderImagePreviews() {
         div.innerHTML = `
             <img src="${img.url}" class="w-full h-full object-cover" alt="">
             <div class="absolute inset-0 bg-slate-950/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
-                <button type="button" onclick="openLightbox('current', ${idx})" class="w-8 h-8 rounded-full bg-emerald-500 text-slate-950 flex items-center justify-center hover:scale-110 transition-transform">
+                <button type="button" onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('current', ${idx})" class="w-8 h-8 rounded-full bg-emerald-500 text-slate-950 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus:ring-2 focus:ring-emerald-500/50">
                     <i class="fa-solid fa-eye"></i>
                 </button>
                 <button type="button" onclick="removeTaskImage(${idx})" class="w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center hover:scale-110 transition-transform">

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -488,8 +488,9 @@ function buildTaskCard(task) {
             ${task.images.map((img, idx) => {
                 const isLegacy = img.type === 'binary_legacy';
                 return `
-                <button type="button" class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative focus:outline-none focus:border-slate-800"
+                <button type="button" class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
                      onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('${task.id}', ${idx})"
+                     onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openLightbox('${task.id}', ${idx}); }"
                      draggable="false">
                     <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
@@ -1968,7 +1969,7 @@ function renderImagePreviews() {
         div.innerHTML = `
             <img src="${img.url}" class="w-full h-full object-cover" alt="">
             <div class="absolute inset-0 bg-slate-950/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
-                <button type="button" onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('current', ${idx})" class="w-8 h-8 rounded-full bg-emerald-500 text-slate-950 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus:ring-2 focus:ring-emerald-500/50">
+                <button type="button" onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('current', ${idx})" onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openLightbox('current', ${idx}); }" class="w-8 h-8 rounded-full bg-emerald-500 text-slate-950 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-white">
                     <i class="fa-solid fa-eye"></i>
                 </button>
                 <button type="button" onclick="removeTaskImage(${idx})" class="w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center hover:scale-110 transition-transform">


### PR DESCRIPTION
This PR fixes the persistent issue where the dashboard lightbox required two interactions to open on touch/tablet devices.

The root cause was identified as a focus-then-click event sequence common in Chromium-based browsers on touch screens, exacerbated by the parent element being draggable. By using `onpointerdown` and `event.preventDefault()`, we intercept the interaction at the earliest possible stage, ensuring immediate feedback and lightbox activation.

Visual hygiene is maintained by suppressing the focus ring on pointer interactions, as requested.

Verified via:
- Manual inspection of the generated build artifacts.
- Local Playwright simulation (mocked environment).

---
*PR created automatically by Jules for task [4974734078016746315](https://jules.google.com/task/4974734078016746315) started by @Axlfc*