### PR TITLE
Fix Lightbox Thumbnail Touch Interaction

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,14 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Lightbox — Rewrite de Interacción Táctil (Critical Fix):</strong> Corregido definitivamente el problema de "eventos fantasma" en dispositivos móviles donde los thumbnails requerían dos toques para abrirse o encolaban el evento para la siguiente interacción.
+                <ul>
+                  <li>Eliminado el uso de etiquetas <code>&lt;button&gt;</code> y listeners inline en el Kanban para evitar conflictos de foco y competencia con el sistema de drag-and-drop.</li>
+                  <li>Implementada inyección vía DOM de thumbnails usando <code>&lt;div role="button"&gt;</code> con <code>tabindex="-1"</code> para eliminar el anillo de foco y el retardo del navegador.</li>
+                  <li>Uso de <code>pointerdown</code> con captura agresiva (<code>capture: true</code>), <code>preventDefault()</code> y <code>stopImmediatePropagation()</code> para garantizar apertura inmediata.</li>
+                  <li>Limpieza de foco automática mediante <code>document.activeElement?.blur()</code> al cerrar el Lightbox.</li>
+                </ul>
+              </li>
               <li><strong>Bug Follow-up — Retardo en apertura de Lightbox:</strong> Corregido definitivamente el problema donde las fotos de las tareas requerían dos interacciones para abrirse en dispositivos táctiles.
                 <ul>
                   <li>Implementado el uso de <code>onpointerdown</code> con <code>event.preventDefault()</code> para interceptar la interacción antes de la separación de eventos de foco/click del navegador.</li>

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -485,18 +485,7 @@ function buildTaskCard(task) {
             <i class="fa-solid fa-chevron-${isImagesExpanded ? 'up' : 'down'}"></i>
         </button>
         <div id="card-images-${task.id}" class="${isImagesExpanded ? '' : 'hidden'} p-2 bg-slate-950 grid grid-cols-3 gap-2">
-            ${task.images.map((img, idx) => {
-                const isLegacy = img.type === 'binary_legacy';
-                return `
-                <button type="button" class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 select-none touch-manipulation"
-                     onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('${task.id}', ${idx})"
-                     onclick="event.preventDefault(); event.stopPropagation();"
-                     onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openLightbox('${task.id}', ${idx}); }"
-                     draggable="false">
-                    <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
-                    ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
-                </button>
-            `;}).join('')}
+            <!-- Thumbs injected via DOM to avoid touch ghost events -->
         </div>
       </div>
       ` : ''}
@@ -545,6 +534,33 @@ function buildTaskCard(task) {
         </div>
       </div>
     `;
+
+    if (hasImages) {
+        const grid = card.querySelector(`#card-images-${task.id}`);
+        if (grid) {
+            task.images.forEach((img, idx) => {
+                const thumbEl = document.createElement('div');
+                thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative';
+                thumbEl.style.cssText = 'touch-action: manipulation; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
+                thumbEl.setAttribute('role', 'button');
+                thumbEl.setAttribute('tabindex', '-1');
+
+                const isLegacy = img.type === 'binary_legacy';
+                thumbEl.innerHTML = `
+                    <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
+                    ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
+                `;
+
+                thumbEl.addEventListener('pointerdown', (e) => {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    openLightbox(String(task.id), idx);
+                }, { capture: true });
+
+                grid.appendChild(thumbEl);
+            });
+        }
+    }
   }
   return card;
 }
@@ -2060,6 +2076,7 @@ function navigateLightbox(direction) {
 }
 
 function closeLightbox() {
+    document.activeElement?.blur();
     const modal = document.getElementById('lightbox-modal');
     if (modal) {
         modal.classList.add('hidden');


### PR DESCRIPTION
This PR fixes a critical bug where lightbox thumbnails on touch devices required multiple taps to open and caused events to be queued and fired on subsequent interactions.

The fix involves:
1.  **Surgical Rewrite of `buildTaskCard`**: Transitioned from rendering thumbnails as `<button>` elements within an HTML string to creating them as `<div>` elements via `document.createElement`. This avoids competition between inline listeners and the parent card's drag-and-drop listeners.
2.  **Pointer Event Management**: Used the `pointerdown` event with capture to trigger the lightbox immediately, while preventing default behavior and stopping propagation to kill ghost `click` events.
3.  **UI/UX Polishing**: Set `tabindex="-1"` and `role="button"` on thumbnails to prevent unwanted focus rings on touch, and ensured all lingering focus is cleared when the lightbox closes.
4.  **Regression Safety**: Maintained existing ID structures for image containers to keep the "expand/collapse" feature functional.

Verified via Playwright simulation on mobile (iPhone 13) and desktop viewports.

---
*PR created automatically by Jules for task [11457711186220299077](https://jules.google.com/task/11457711186220299077) started by @Axlfc*