### PR TITLE
fix: critical rewrite of lightbox touch interaction on tablets

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,16 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Lightbox — Rewrite de Interacción Táctil (Critical Fix):</strong> Corregido definitivamente el problema de "eventos fantasma" en dispositivos móviles donde los thumbnails requerían dos toques para abrirse o encolaban el evento para la siguiente interacción.
+                <ul>
+                  <li>Eliminado el uso de etiquetas <code>&lt;button&gt;</code> y listeners inline en el Kanban para evitar conflictos de foco y competencia con el sistema de drag-and-drop.</li>
+                  <li>Implementada inyección vía DOM de thumbnails usando <code>&lt;div role="button"&gt;</code> con <code>tabindex="-1"</code> para eliminar el anillo de foco y el retardo del navegador.</li>
+                  <li>Uso de <code>pointerdown</code> con captura agresiva (<code>capture: true</code>), <code>preventDefault()</code> y <code>stopImmediatePropagation()</code> para garantizar apertura inmediata.</li>
+                  <li>Implementado bypass temporal de draggability del card padre y fallback de <code>touchstart</code> para máxima compatibilidad en tablets.</li>
+                  <li>Limpieza de foco automática mediante <code>document.activeElement?.blur()</code> al cerrar el Lightbox.</li>
+                  <li>Eliminación global de anillos de foco y highlight táctil en elementos con <code>role="button"</code>.</li>
+                </ul>
+              </li>
               <li><strong>Bug Follow-up — Retardo en apertura de Lightbox:</strong> Corregido definitivamente el problema donde las fotos de las tareas requerían dos interacciones para abrirse en dispositivos táctiles.
                 <ul>
                   <li>Implementado el uso de <code>onpointerdown</code> con <code>event.preventDefault()</code> para interceptar la interacción antes de la separación de eventos de foco/click del navegador.</li>

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -485,18 +485,7 @@ function buildTaskCard(task) {
             <i class="fa-solid fa-chevron-${isImagesExpanded ? 'up' : 'down'}"></i>
         </button>
         <div id="card-images-${task.id}" class="${isImagesExpanded ? '' : 'hidden'} p-2 bg-slate-950 grid grid-cols-3 gap-2">
-            ${task.images.map((img, idx) => {
-                const isLegacy = img.type === 'binary_legacy';
-                return `
-                <button type="button" class="aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer hover:border-emerald-500 transition-all relative focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 select-none touch-manipulation"
-                     onpointerdown="event.preventDefault(); event.stopPropagation(); openLightbox('${task.id}', ${idx})"
-                     onclick="event.preventDefault(); event.stopPropagation();"
-                     onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openLightbox('${task.id}', ${idx}); }"
-                     draggable="false">
-                    <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
-                    ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
-                </button>
-            `;}).join('')}
+            <!-- Thumbs injected via DOM to avoid touch ghost events -->
         </div>
       </div>
       ` : ''}
@@ -545,6 +534,41 @@ function buildTaskCard(task) {
         </div>
       </div>
     `;
+
+    if (hasImages) {
+        const grid = card.querySelector(`#card-images-${task.id}`);
+        if (grid) {
+            task.images.forEach((img, idx) => {
+                const thumbEl = document.createElement('div');
+                thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative';
+                thumbEl.style.cssText = 'touch-action: manipulation; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
+                thumbEl.setAttribute('role', 'button');
+                thumbEl.setAttribute('tabindex', '-1');
+
+                const isLegacy = img.type === 'binary_legacy';
+                thumbEl.innerHTML = `
+                    <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
+                    ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
+                `;
+
+                thumbEl.addEventListener('pointerdown', (e) => {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    card.draggable = false;
+                    setTimeout(() => { card.draggable = true; }, 300);
+                    openLightbox(String(task.id), idx);
+                }, { capture: true });
+
+                thumbEl.addEventListener('touchstart', (e) => {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    openLightbox(String(task.id), idx);
+                }, { capture: true, passive: false });
+
+                grid.appendChild(thumbEl);
+            });
+        }
+    }
   }
   return card;
 }
@@ -2060,6 +2084,7 @@ function navigateLightbox(direction) {
 }
 
 function closeLightbox() {
+    document.activeElement?.blur();
     const modal = document.getElementById('lightbox-modal');
     if (modal) {
         modal.classList.add('hidden');

--- a/dashboard.html
+++ b/dashboard.html
@@ -34,6 +34,8 @@
         .custom-scrollbar::-webkit-scrollbar-track { background: #0f172a; }
         .custom-scrollbar::-webkit-scrollbar-thumb { background: #334155; border-radius: 10px; }
         .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #475569; }
+
+        [role="button"] { outline: none !important; -webkit-tap-highlight-color: transparent !important; }
     </style>
 </head>
 <body class="h-full text-slate-100 flex flex-col">


### PR DESCRIPTION
- Implement low-level `pointerdown` and `touchstart` listeners with capture to bypass mobile event delays and focus ghosting.
- Fix conflict with draggable cards by temporarily disabling `draggable` on parent card during thumbnail interaction.
- Transition thumbnails from `<button>` strings to `<div>` elements injected via DOM for reliable event binding.
- Add global CSS overrides to eliminate green focus rings and -webkit tap highlights.
- Ensure all lingering focus is cleared on lightbox close via `document.activeElement.blur()`.
- Update CHANGELOG.html with detailed fix description.