### PR TITLE
fix: Kanban thumbnail interaction for mobile, tablet, and desktop

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Lightbox — Kanban Thumbnail Mobile & Tablet Fix:</strong> Corregido el problema donde las miniaturas de imagen en las tarjetas del Kanban no abrían el visor en dispositivos móviles y tablets al entrar en conflicto con el sistema de arrastre (<code>draggable</code>). Se implementó un sistema de delegación de eventos en el card padre que intercepta tanto <code>touchstart</code> como <code>click</code> sobre botones de miniatura usando <code>capture: true</code>, garantizando una respuesta inmediata y compatibilidad total entre dispositivos táctiles y de escritorio.</li>
               <li><strong>Lightbox — Rewrite de Interacción Táctil (Critical Fix):</strong> Corregido definitivamente el problema de "eventos fantasma" en dispositivos móviles donde los thumbnails requerían dos toques para abrirse o encolaban el evento para la siguiente interacción.
                 <ul>
                   <li>Eliminado el uso de etiquetas <code>&lt;button&gt;</code> y listeners inline en el Kanban para evitar conflictos de foco y competencia con el sistema de drag-and-drop.</li>

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -405,6 +405,27 @@ function buildTaskCard(task) {
   });
   card.addEventListener('dragend', () => card.classList.remove('opacity-50'));
 
+  card.addEventListener('touchstart', function(e) {
+      const btn = e.target.closest('button[data-lightbox-task]');
+      if (!btn) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const taskId = btn.getAttribute('data-lightbox-task');
+      const idx = parseInt(btn.getAttribute('data-lightbox-idx'), 10);
+      openLightbox(taskId, idx);
+  }, { capture: true, passive: false });
+
+  // Desktop/Mouse Support
+  card.addEventListener('click', function(e) {
+      const btn = e.target.closest('button[data-lightbox-task]');
+      if (!btn) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const taskId = btn.getAttribute('data-lightbox-task');
+      const idx = parseInt(btn.getAttribute('data-lightbox-idx'), 10);
+      openLightbox(taskId, idx);
+  }, { capture: true });
+
   const priorityColors = {
     Critical: 'bg-red-500 text-slate-950 font-black',
     Major:    'bg-orange-500 text-slate-950 font-black',
@@ -549,38 +570,14 @@ function buildTaskCard(task) {
                 thumbEl.innerHTML = `
                     <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
+                    <button
+                        type="button"
+                        data-lightbox-task="${String(task.id)}"
+                        data-lightbox-idx="${idx}"
+                        class="absolute inset-0 w-full h-full opacity-0"
+                        style="touch-action: manipulation; -webkit-tap-highlight-color: transparent;"
+                    ></button>
                 `;
-
-                // DESPUÉS (fix móvil):
-                let touchMoved = false;
-                
-                thumbEl.addEventListener('touchstart', function(e) {
-                    touchMoved = false;
-                    e.stopPropagation();
-                    // Desactivar drag en el padre para que no robe el gesto
-                    card.draggable = false;
-                }, { passive: true, capture: true });
-                
-                thumbEl.addEventListener('touchmove', function(e) {
-                    touchMoved = true;
-                }, { passive: true });
-                
-                thumbEl.addEventListener('touchend', function(e) {
-                    card.draggable = true;
-                    if (!touchMoved) {
-                        e.preventDefault();
-                        e.stopImmediatePropagation();
-                        openLightbox(String(task.id), idx);
-                    }
-                }, { capture: true });
-                
-                // Mantener el pointerdown solo para desktop (mouse)
-                thumbEl.addEventListener('pointerdown', function(e) {
-                    if (e.pointerType === 'touch') return; // touch ya manejado arriba
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                    openLightbox(String(task.id), idx);
-                }, { capture: true });
 
                 grid.appendChild(thumbEl);
             });


### PR DESCRIPTION
Refined the Kanban thumbnail interaction by implementing event delegation on the task card element. Added 'touchstart' (with capture) and 'click' listeners to intercept interactions with thumbnail buttons, resolving conflicts with the card's draggable attribute and ensuring immediate lightbox activation across all devices. Updated CHANGELOG.html to reflect the implementation.