### PR TITLE
Fix Kanban Image Click & Drag Interference

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,14 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Kanban — Image Click & Drag Interference (Critical Fix):</strong> Solucionado el problema donde las miniaturas de imagen no abrían el visor de forma consistente debido a interferencias con el arrastre de la tarjeta y el uso de botones invisibles.
+                <ul>
+                  <li>Eliminados los botones invisibles sobre las miniaturas en favor de listeners directos.</li>
+                  <li>Implementado <code>data-no-drag="true"</code> y filtrado de <code>dragstart</code> para evitar el arrastre accidental al interactuar con imágenes, selectores o botones.</li>
+                  <li>Estandarizada la lógica de previsualización de imágenes tanto en el Kanban como en el Modal de Edición.</li>
+                  <li>Cambiado el estado por defecto de las tarjetas a <strong>minimizadas</strong> para una mejor visualización del tablero.</li>
+                </ul>
+              </li>
               <li><strong>Dashboard — Corregida regresión de clicks en tarjetas:</strong> Solucionado el problema de "clicks fantasma" donde pulsar el botón de edición o elementos internos podía disparar accidentalmente el visor de imágenes o interferir con la apertura de modales.
                 <ul>
                   <li>Se ha implementado <code>event.stopPropagation()</code> en todos los elementos interactivos de las tarjetas (botones, selectores, avatares).</li>

--- a/assets/javascript/dashboard.js
+++ b/assets/javascript/dashboard.js
@@ -22,6 +22,14 @@ function sameTaskId(id1, id2) {
     return String(id1) === String(id2);
 }
 
+/**
+ * Helper to check if a task is minimized, defaulting to true if no preference exists.
+ */
+function isTaskMinimized(taskId) {
+    const value = localStorage.getItem(`task_minimized_${String(taskId)}`);
+    return value === null ? true : value === 'true';
+}
+
 let activeFilter = null;
 let activeStageFilter = null;
 let currentTasks = [];
@@ -350,7 +358,7 @@ function renderKanbanBoard() {
   // Update Global Toggle Icon
   const globalToggle = document.getElementById('global-kanban-toggle');
   if (globalToggle) {
-    const anyExpanded = tasks.some(t => localStorage.getItem(`task_minimized_${t.id}`) !== 'true');
+    const anyExpanded = tasks.some(t => !isTaskMinimized(t.id));
     const icon = globalToggle.querySelector('i');
     if (icon) {
       icon.className = anyExpanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down';
@@ -393,13 +401,18 @@ function getTaskColumn(task) {
 }
 
 function buildTaskCard(task) {
-  const isMinimized = localStorage.getItem(`task_minimized_${task.id}`) === 'true';
+  const isMinimized = isTaskMinimized(task.id);
   const hasImages = task.images && task.images.length > 0;
   const isImagesExpanded = localStorage.getItem(`task_images_expanded_${task.id}`) === 'true';
   const card = document.createElement('div');
   card.className = `bg-slate-800 p-4 rounded-xl border border-slate-700 shadow-sm cursor-grab active:cursor-grabbing hover:border-slate-500 transition-all group relative ${isMinimized ? 'py-2' : ''}`;
   card.draggable = true;
   card.addEventListener('dragstart', e => {
+    if (e.target.closest('button, select, input, textarea, a, [data-no-drag="true"]')) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     e.dataTransfer.setData('text/plain', String(task.id));
     card.classList.add('opacity-50');
   });
@@ -544,18 +557,25 @@ function buildTaskCard(task) {
                 thumbEl.style.cssText = 'touch-action: manipulation; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
                 thumbEl.setAttribute('role', 'button');
                 thumbEl.setAttribute('tabindex', '-1');
+                thumbEl.draggable = false;
+                thumbEl.dataset.noDrag = 'true';
 
                 const isLegacy = img.type === 'binary_legacy';
                 thumbEl.innerHTML = `
                     <img src="${img.url}" class="w-full h-full object-cover pointer-events-none" alt="Task image" loading="lazy" draggable="false">
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
-                    <button
-                        type="button"
-                        onclick="openImagePreview('${String(task.id)}', ${idx}, event)"
-                        class="absolute inset-0 w-full h-full opacity-0"
-                        style="touch-action: manipulation; -webkit-tap-highlight-color: transparent;"
-                    ></button>
                 `;
+
+                thumbEl.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    openLightbox(String(task.id), idx);
+                });
+
+                thumbEl.addEventListener('dragstart', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                });
 
                 grid.appendChild(thumbEl);
             });
@@ -567,7 +587,7 @@ function buildTaskCard(task) {
 
 function toggleTaskMinimize(taskId) {
   const key = `task_minimized_${String(taskId)}`;
-  const current = localStorage.getItem(key) === 'true';
+  const current = isTaskMinimized(taskId);
   localStorage.setItem(key, !current);
   renderKanbanBoard();
 }
@@ -581,10 +601,10 @@ function toggleCardImages(taskId) {
 
 function toggleAllTasks() {
   const tasks = getFilteredTasks(currentTasks.filter(t => t.estado !== 'Obsolete'));
-  const anyExpanded = tasks.some(t => localStorage.getItem(`task_minimized_${t.id}`) !== 'true');
+  const anyExpanded = tasks.some(t => !isTaskMinimized(t.id));
 
   // If any expanded -> minimize all. If all minimized -> expand all.
-  const newState = anyExpanded; // if anyExpanded is true, we want to minimize (set to true)
+  const newState = anyExpanded;
 
   tasks.forEach(t => {
     localStorage.setItem(`task_minimized_${t.id}`, newState);
@@ -1993,10 +2013,10 @@ function renderImagePreviews() {
         div.innerHTML = `
             <img src="${img.url}" class="w-full h-full object-cover" alt="">
             <div class="absolute inset-0 bg-slate-950/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
-                <button type="button" onclick="openImagePreview('current', ${idx}, event)" class="w-8 h-8 rounded-full bg-emerald-500 text-slate-950 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-white select-none touch-manipulation">
+                <button type="button" data-action="preview-image" class="w-8 h-8 rounded-full bg-emerald-500 text-slate-950 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-white select-none touch-manipulation">
                     <i class="fa-solid fa-eye"></i>
                 </button>
-                <button type="button" onclick="event.stopPropagation(); removeTaskImage(${idx})" class="w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center hover:scale-110 transition-transform">
+                <button type="button" data-action="remove-image" class="w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center hover:scale-110 transition-transform">
                     <i class="fa-solid fa-trash"></i>
                 </button>
             </div>
@@ -2004,6 +2024,21 @@ function renderImagePreviews() {
             <div class="name-label absolute bottom-0 left-0 right-0 p-1 bg-slate-950/80 text-[8px] text-slate-300 truncate pointer-events-none">
             </div>
         `;
+
+        const previewBtn = div.querySelector('[data-action="preview-image"]');
+        previewBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            openLightbox('current', idx);
+        });
+
+        const removeBtn = div.querySelector('[data-action="remove-image"]');
+        removeBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            removeTaskImage(idx);
+        });
+
         div.querySelector('.name-label').textContent = img.filename || 'Imagen';
         container.appendChild(div);
     });

--- a/jekyll.log
+++ b/jekyll.log
@@ -5,204 +5,186 @@ To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
  Incremental build: disabled. Enable with --incremental
       Generating...
        Jekyll Feed: Generating feed for posts
-                    done in 5.188 seconds.
+                    done in 4.727 seconds.
  Auto-regeneration: enabled for '/app'
-    Server address: http://127.0.0.1:8000
+    Server address: http://127.0.0.1:4000
   Server running... press ctrl-c to stop.
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:02
+      Regenerating: 1 file(s) changed at 2026-06-01 18:44:37
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 5.01843375 seconds.
+                    ...done in 4.678685698 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:07
+      Regenerating: 1 file(s) changed at 2026-06-01 18:44:42
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.774091431 seconds.
+                    ...done in 4.477972104 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:12
+      Regenerating: 1 file(s) changed at 2026-06-01 18:44:46
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.914166829 seconds.
+                    ...done in 4.722197013 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:17
+      Regenerating: 1 file(s) changed at 2026-06-01 18:44:51
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.865871937 seconds.
+                    ...done in 4.53025116 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:22
+      Regenerating: 1 file(s) changed at 2026-06-01 18:44:56
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.739673376 seconds.
+                    ...done in 4.471158341 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:26
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:00
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.738424727 seconds.
+                    ...done in 4.484457231 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:31
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:05
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 6.529066306 seconds.
+                    ...done in 4.463025825 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:38
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:09
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.794715218 seconds.
+                    ...done in 4.555923427 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:43
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:14
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.766948236 seconds.
+                    ...done in 6.038573943 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:48
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:20
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.786091634 seconds.
+                    ...done in 4.472810885 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:52
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:25
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 5.042400971 seconds.
+                    ...done in 6.067311945 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:42:58
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:31
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.722384579 seconds.
+                    ...done in 4.662356599 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:02
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:36
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.807155976 seconds.
+                    ...done in 4.466730435 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:07
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:40
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 5.043357831 seconds.
+                    ...done in 4.745346241 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:12
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:45
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.847465406 seconds.
+                    ...done in 4.465686067 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:17
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:50
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.822187511 seconds.
+                    ...done in 4.629852383 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:22
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:54
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.757565507 seconds.
+                    ...done in 4.439344966 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:27
+      Regenerating: 1 file(s) changed at 2026-06-01 18:45:59
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.862432612 seconds.
+                    ...done in 4.519666976 seconds.
 
-      Regenerating: 2 file(s) changed at 2026-06-01 08:43:32
-                    jekyll.log
-                    assets/javascript/github-api.js
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.734180504 seconds.
-
-      Regenerating: 2 file(s) changed at 2026-06-01 08:43:37
-                    jekyll.log
-                    assets/javascript/dashboard.js
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.702743079 seconds.
-
-      Regenerating: 2 file(s) changed at 2026-06-01 08:43:42
-                    jekyll.log
-                    assets/javascript/github-api.js
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.672325242 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:47
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.728048401 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:51
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.659544918 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:43:56
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.77222108 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:01
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.705063278 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:06
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.68915692 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:11
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.663674975 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:15
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.692058439 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:20
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.720664686 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:25
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.72906545 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:30
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.750149478 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:35
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 6.674809019 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:41
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 4.732659198 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:46
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 6.624170745 seconds.
-
-      Regenerating: 1 file(s) changed at 2026-06-01 08:44:53
-                    jekyll.log
-       Jekyll Feed: Generating feed for posts
-                    ...done in 5.615126459 seconds.
-
-      Regenerating: 2 file(s) changed at 2026-06-01 08:44:59
+      Regenerating: 2 file(s) changed at 2026-06-01 18:46:03
                     jekyll.log
                     CHANGELOG.html
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.770385067 seconds.
+                    ...done in 4.614011198 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:45:04
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:08
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.692720236 seconds.
+                    ...done in 4.555462931 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:45:08
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:13
                     jekyll.log
        Jekyll Feed: Generating feed for posts
-                    ...done in 4.757761913 seconds.
+                    ...done in 4.781351434 seconds.
 
-      Regenerating: 1 file(s) changed at 2026-06-01 08:45:13
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:18
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.553084314 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:22
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.613362904 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:27
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 5.353647107 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:33
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.52809248 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:37
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.813520244 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:42
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.842362695 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:47
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.591632266 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:52
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.594446635 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:46:56
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.58039918 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:47:01
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.627789849 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:47:06
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.570397086 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:47:11
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.549488058 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:47:15
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 6.075762002 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:47:21
+                    jekyll.log
+       Jekyll Feed: Generating feed for posts
+                    ...done in 4.45772092 seconds.
+
+      Regenerating: 1 file(s) changed at 2026-06-01 18:47:26
                     jekyll.log
        Jekyll Feed: Generating feed for posts


### PR DESCRIPTION
This PR fixes a critical issue where image thumbnails in Kanban cards were difficult to click due to interference with the card's drag-and-drop property and the use of fragile invisible button overlays.

Key changes:
1. **Event Handling**: Removed the invisible `<button>` overlays on thumbnails. Added direct `click` and `dragstart` listeners to `thumbEl` with `stopPropagation()` to ensure clean interaction.
2. **Drag Filtering**: Implemented a filter in the card's `dragstart` listener to ignore events originating from buttons, selects, inputs, or elements with `data-no-drag="true"`.
3. **Default State**: Changed the default state of task cards to 'minimized' for a cleaner initial view. This is managed via a new `isTaskMinimized(taskId)` helper.
4. **Consistency**: Applied the same listener refactoring to the edit modal's image previews.
5. **Changelog**: Added an entry to `CHANGELOG.html` describing these improvements.

---
*PR created automatically by Jules for task [12173665755480802537](https://jules.google.com/task/12173665755480802537) started by @TopperH4rley*