### PR TITLE
Fix Lightbox Touch Bug on Tablet

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Lightbox — Pointer Events & Ghost Click Suppression:</strong> Reemplazo completo de <code>click</code> por <code>pointerdown</code> con <code>stopImmediatePropagation</code> en miniaturas del Kanban para una respuesta instantánea en tablets. Se ha añadido un listener de captura para anular "ghost clicks" y una breve suspensión del <code>draggable</code> del card (300ms) para evitar colisiones con el sistema de arrastre.</li>
               <li><strong>Kanban — Image Click & Drag Interference (Critical Fix):</strong> Solucionado el problema donde las miniaturas de imagen no abrían el visor de forma consistente debido a interferencias con el arrastre de la tarjeta y el uso de botones invisibles.
                 <ul>
                   <li>Eliminados los botones invisibles sobre las miniaturas en favor de listeners directos.</li>

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -214,11 +214,18 @@ function buildTaskCard(task) {
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
                 `;
 
-                thumbEl.addEventListener('click', (event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
+                thumbEl.addEventListener('pointerdown', (e) => {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    card.draggable = false;
+                    setTimeout(() => { card.draggable = true; }, 300);
                     openLightbox(String(task.id), idx);
                 });
+
+                thumbEl.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                }, { capture: true });
 
                 thumbEl.addEventListener('dragstart', (event) => {
                     event.preventDefault();

--- a/dashboard.html
+++ b/dashboard.html
@@ -36,6 +36,8 @@
         .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #475569; }
 
         [role="button"] { outline: none !important; -webkit-tap-highlight-color: transparent !important; }
+        .kanban-cards { touch-action: pan-x pan-y; }
+        .kanban-cards [role="button"] { touch-action: manipulation; }
     </style>
 </head>
 <body class="h-full text-slate-100 flex flex-col">


### PR DESCRIPTION
This PR fixes the issue where the lightbox would not open correctly on the first tap on tablet devices.

Key changes:
1. **Pointer Events**: Switched from `click` to `pointerdown` for task thumbnails in `assets/javascript/dashboard-kanban.js`. This provides immediate feedback and bypasses the 300ms click delay.
2. **Event Suppression**: Used `e.stopImmediatePropagation()` and `e.preventDefault()` on `pointerdown` to prevent the event from bubbling up to the card's drag-and-drop handlers.
3. **Ghost Click Prevention**: Added a capturing `click` listener on thumbnails to "swallow" emulated click events generated by the browser after a touch sequence.
4. **Drag Suppression**: Temporarily sets `card.draggable = false` for 300ms when a thumbnail is tapped, preventing accidental drag starts.
5. **Touch Action CSS**: Added CSS rules to `dashboard.html` to optimize touch interactions on the Kanban board, allowing for smooth scrolling while ensuring buttons are responsive.

---
*PR created automatically by Jules for task [3006920835266510978](https://jules.google.com/task/3006920835266510978) started by @Axlfc*