### PR TITLE
Fix Lightbox tablet interaction and parent drag conflicts

### DIFF
--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -56,7 +56,11 @@ function buildTaskCard(task) {
   card.className = `bg-slate-800 p-4 rounded-xl border border-slate-700 shadow-sm cursor-grab active:cursor-grabbing hover:border-slate-500 transition-all group relative ${isMinimized ? 'py-2' : ''}`;
   card.draggable = true;
   card.addEventListener('dragstart', e => {
-    if (e.target.closest('button, select, input, textarea, a, [data-no-drag="true"]')) {
+    if (e.target.closest('[data-no-drag="true"]')) {
+        e.preventDefault();
+        return;
+    }
+    if (e.target.closest('button, select, input, textarea, a')) {
       e.preventDefault();
       e.stopPropagation();
       return;
@@ -202,7 +206,7 @@ function buildTaskCard(task) {
             task.images.forEach((img, idx) => {
                 const thumbEl = document.createElement('div');
                 thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative';
-                thumbEl.style.cssText = 'touch-action: manipulation; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
+                thumbEl.style.cssText = 'touch-action: none; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
                 thumbEl.setAttribute('role', 'button');
                 thumbEl.setAttribute('tabindex', '-1');
                 thumbEl.draggable = false;
@@ -214,12 +218,21 @@ function buildTaskCard(task) {
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
                 `;
 
+                let _lightboxFired = false;
                 thumbEl.addEventListener('pointerdown', (e) => {
                     e.preventDefault();
                     e.stopImmediatePropagation();
+                    _lightboxFired = false;
                     card.draggable = false;
                     setTimeout(() => { card.draggable = true; }, 300);
+                    _lightboxFired = true;
                     openLightbox(String(task.id), idx);
+                });
+
+                thumbEl.addEventListener('pointercancel', (e) => {
+                    if (!_lightboxFired) {
+                        openLightbox(String(task.id), idx);
+                    }
                 });
 
                 thumbEl.addEventListener('click', (e) => {


### PR DESCRIPTION
This PR fixes an issue where clicking/tapping task thumbnails on tablets would fail to open the lightbox or trigger the wrong element (like the edit button) due to touch gestures being cancelled by the parent card's drag behavior.

Key changes:
1.  **Thumbnail Touch Handling:** Applied `touch-action: none` to thumbnails, ensuring pointer events are handled exclusively by JavaScript.
2.  **Pointer Fallback:** Added a `pointercancel` listener as a fallback to `pointerdown`, using a `_lightboxFired` flag to ensure the lightbox opens exactly once.
3.  **Drag Suppression:** Enhanced the `dragstart` listener on task cards to explicitly respect the `[data-no-drag="true"]` attribute, preventing drag initiation when interacting with thumbnails.
4.  **Race Condition Prevention:** Temporarily disabled card draggability on thumbnail interaction to avoid conflicts between touch and drag-and-drop APIs.

---
*PR created automatically by Jules for task [7551530165185283492](https://jules.google.com/task/7551530165185283492) started by @Axlfc*