### PR TITLE
Nuclear fix: Replace touch event approach with anchor tag navigation for thumbnails

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,13 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Kanban — Solución Definitiva para Miniaturas (Nuclear Fix):</strong> Reemplazo completo del sistema de eventos táctiles por navegación nativa mediante etiquetas <code>&lt;a&gt;</code>.
+                <ul>
+                  <li>Eliminados todos los listeners de <code>pointerdown</code>, <code>touchstart</code> y <code>pointercancel</code> que causaban conflictos en tablets.</li>
+                  <li>Uso de <code>onclick</code> directo en el elemento anchor para máxima prioridad en el navegador.</li>
+                  <li>Optimizado el listener de <code>dragstart</code> del card padre para no interferir con los clics en las miniaturas, manteniendo la funcionalidad de arrastre del card desde el fondo.</li>
+                </ul>
+              </li>
               <li><strong>Lightbox — Pointer Events & Ghost Click Suppression:</strong> Reemplazo completo de <code>click</code> por <code>pointerdown</code> con <code>stopImmediatePropagation</code> en miniaturas del Kanban para una respuesta instantánea en tablets. Se ha añadido un listener de captura para anular "ghost clicks" y una breve suspensión del <code>draggable</code> del card (300ms) para evitar colisiones con el sistema de arrastre.</li>
               <li><strong>Kanban — Image Click & Drag Interference (Critical Fix):</strong> Solucionado el problema donde las miniaturas de imagen no abrían el visor de forma consistente debido a interferencias con el arrastre de la tarjeta y el uso de botones invisibles.
                 <ul>

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -60,14 +60,14 @@ function buildTaskCard(task) {
         e.preventDefault();
         return;
     }
-    if (e.target.closest('button, select, input, textarea, a')) {
-      e.preventDefault();
-      e.stopPropagation();
-      return;
+    if (e.target.closest('button, select, input, textarea')) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
     }
     e.dataTransfer.setData('text/plain', String(task.id));
     card.classList.add('opacity-50');
-  });
+});
   card.addEventListener('dragend', () => card.classList.remove('opacity-50'));
 
   const priorityColors = {
@@ -204,11 +204,11 @@ function buildTaskCard(task) {
         const grid = card.querySelector(`#card-images-${task.id}`);
         if (grid) {
             task.images.forEach((img, idx) => {
-                const thumbEl = document.createElement('div');
-                thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative';
-                thumbEl.style.cssText = 'touch-action: none; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
-                thumbEl.setAttribute('role', 'button');
-                thumbEl.setAttribute('tabindex', '-1');
+                const thumbEl = document.createElement('a');
+                thumbEl.href = 'javascript:void(0)';
+                thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative block';
+                thumbEl.style.cssText = '-webkit-tap-highlight-color: transparent; outline: none; user-select: none; display: block;';
+                thumbEl.setAttribute('tabindex', '0');
                 thumbEl.draggable = false;
                 thumbEl.dataset.noDrag = 'true';
 
@@ -218,32 +218,12 @@ function buildTaskCard(task) {
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
                 `;
 
-                let _lightboxFired = false;
-                thumbEl.addEventListener('pointerdown', (e) => {
+                thumbEl.onclick = function(e) {
                     e.preventDefault();
-                    e.stopImmediatePropagation();
-                    _lightboxFired = false;
-                    card.draggable = false;
-                    setTimeout(() => { card.draggable = true; }, 300);
-                    _lightboxFired = true;
+                    e.stopPropagation();
                     openLightbox(String(task.id), idx);
-                });
-
-                thumbEl.addEventListener('pointercancel', (e) => {
-                    if (!_lightboxFired) {
-                        openLightbox(String(task.id), idx);
-                    }
-                });
-
-                thumbEl.addEventListener('click', (e) => {
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                }, { capture: true });
-
-                thumbEl.addEventListener('dragstart', (event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                });
+                    return false;
+                };
 
                 grid.appendChild(thumbEl);
             });


### PR DESCRIPTION
This PR implements a "nuclear fix" for thumbnail interactions on tablets and mobile browsers. Every previous touch event approach had failed on certain tablet/browser combinations. By switching to a native `<a>` tag with a direct `onclick` property, we ensure that taps are treated as navigation intent (highest priority), avoiding the 300ms delay and focus/blur issues common on mobile.

Key changes:
1. **Thumbnail Re-architecture**: In `assets/javascript/dashboard-kanban.js`, thumbnails are now created as `<a>` elements with `href='javascript:void(0)'`.
2. **Event Cleanup**: Removed all manual touch/pointer event handling (`pointerdown`, `pointercancel`, `click` capture) that previously attempted to manage the click vs. drag conflict.
3. **Drag-and-Drop Optimization**: Updated the parent card's `dragstart` listener to specifically check for the `[data-no-drag="true"]` attribute (applied to thumbnails) and removed the global `<a>` tag block. This allows the card to be dragged normally from its background while still protecting the thumbnails' interactive nature.

---
*PR created automatically by Jules for task [12800166267692148332](https://jules.google.com/task/12800166267692148332) started by @Axlfc*