### PR TITLE
fix: nuclear minimalist redesign of image interaction

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -117,6 +117,14 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Lightbox — Nuclear Minimalist Fix:</strong> Rediseño total de la interacción de imágenes en el Kanban para eliminar fricción y "clics fantasma".
+                <ul>
+                    <li>Eliminado el botón colapsable "{n} imagenes" en favor de una previsualización directa y minimalista en la tarjeta.</li>
+                    <li>Uso de <code>div</code> con <code>touch-action: none</code> para las miniaturas, forzando una respuesta instantánea al <code>pointerdown</code>.</li>
+                    <li>Supresión agresiva de eventos concurrentes (<code>touchstart</code>, <code>click</code>) mediante <code>stopImmediatePropagation</code> para aislar completamente la apertura del visor del sistema de arrastre del Kanban.</li>
+                    <li>Eliminado el retardo de seguridad (guard) de 300ms en el Lightbox para una respuesta inmediata.</li>
+                </ul>
+              </li>
               <li><strong>Kanban — Solución Definitiva para Miniaturas (Nuclear Fix):</strong> Reemplazo completo del sistema de eventos táctiles por navegación nativa mediante etiquetas <code>&lt;a&gt;</code>.
                 <ul>
                   <li>Eliminados todos los listeners de <code>pointerdown</code>, <code>touchstart</code> y <code>pointercancel</code> que causaban conflictos en tablets.</li>

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -144,14 +144,8 @@ function buildTaskCard(task) {
       ${task.title ? `<p class="text-[11px] text-slate-400 leading-tight mb-3 line-clamp-2">${task.descripcion}</p>` : ''}
 
       ${hasImages ? `
-      <div class="mb-3 border border-slate-700 rounded-lg overflow-hidden">
-        <button onclick="event.stopPropagation(); toggleCardImages('${task.id}')" class="w-full flex items-center justify-between p-2 bg-slate-900/50 hover:bg-slate-900 transition-all text-[10px] font-bold text-slate-400">
-            <span><i class="fa-solid fa-paperclip mr-1"></i> ${task.images.length} imagen${task.images.length === 1 ? '' : 'es'}</span>
-            <i class="fa-solid fa-chevron-${isImagesExpanded ? 'up' : 'down'}"></i>
-        </button>
-        <div id="card-images-${task.id}" class="${isImagesExpanded ? '' : 'hidden'} p-2 bg-slate-950 grid grid-cols-3 gap-2">
-            <!-- Thumbnails injected via DOM to avoid touch ghost events -->
-        </div>
+      <div class="mb-3 grid grid-cols-3 gap-2" id="card-images-${task.id}">
+          <!-- Thumbnails injected via DOM to avoid touch ghost events -->
       </div>
       ` : ''}
 
@@ -204,11 +198,9 @@ function buildTaskCard(task) {
         const grid = card.querySelector(`#card-images-${task.id}`);
         if (grid) {
             task.images.forEach((img, idx) => {
-                const thumbEl = document.createElement('a');
-                thumbEl.href = 'javascript:void(0)';
-                thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative block';
-                thumbEl.style.cssText = '-webkit-tap-highlight-color: transparent; outline: none; user-select: none; display: block;';
-                thumbEl.setAttribute('tabindex', '0');
+                const thumbEl = document.createElement('div');
+                thumbEl.className = 'aspect-square rounded border border-slate-800 overflow-hidden cursor-pointer relative block bg-slate-900';
+                thumbEl.style.cssText = 'touch-action: none; -webkit-tap-highlight-color: transparent; outline: none; user-select: none;';
                 thumbEl.draggable = false;
                 thumbEl.dataset.noDrag = 'true';
 
@@ -218,12 +210,20 @@ function buildTaskCard(task) {
                     ${isLegacy ? '<span class="absolute top-0.5 left-0.5 bg-amber-500 text-slate-950 text-[6px] font-black px-0.5 rounded shadow-sm">⚠️ LEGACY</span>' : ''}
                 `;
 
-                thumbEl.onclick = function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
+                const handleLightboxOpen = function(e) {
+                    if (e) {
+                        e.preventDefault();
+                        e.stopImmediatePropagation(); // More aggressive than stopPropagation
+                    }
                     openLightbox(String(task.id), idx);
                     return false;
                 };
+
+                // Use pointerdown for immediate response, bypasses drag delay
+                thumbEl.onpointerdown = handleLightboxOpen;
+                // Swallowing other events to prevent ghost clicks or parent reactions
+                thumbEl.ontouchstart = (e) => { e.preventDefault(); e.stopImmediatePropagation(); };
+                thumbEl.onclick = (e) => { e.preventDefault(); e.stopImmediatePropagation(); };
 
                 grid.appendChild(thumbEl);
             });

--- a/assets/javascript/dashboard-tasks.js
+++ b/assets/javascript/dashboard-tasks.js
@@ -371,11 +371,18 @@ function renderImagePreviews() {
         `;
 
         const previewBtn = div.querySelector('[data-action="preview-image"]');
-        previewBtn.addEventListener('click', (event) => {
-            event.preventDefault();
-            event.stopPropagation();
+        const handlePreview = (event) => {
+            if (event) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+            document.activeElement?.blur();
             openLightbox('current', idx);
-        });
+            return false;
+        };
+        previewBtn.onpointerdown = handlePreview;
+        previewBtn.ontouchstart = (e) => { e.preventDefault(); e.stopImmediatePropagation(); };
+        previewBtn.onclick = (e) => { e.preventDefault(); e.stopImmediatePropagation(); };
 
         const removeBtn = div.querySelector('[data-action="remove-image"]');
         removeBtn.addEventListener('click', (event) => {
@@ -584,5 +591,7 @@ function openImagePreview(taskId, idx, event) {
         if (typeof event.stopPropagation === 'function') event.stopPropagation();
         if (typeof event.preventDefault === 'function') event.preventDefault();
     }
+    // Phase 3 Fix: ensure we don't have pending click states
+    document.activeElement?.blur();
     openLightbox(taskId, idx);
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -695,7 +695,7 @@
     </div>
 
     <!-- Lightbox Modal -->
-    <div id="lightbox-modal" class="hidden fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/95 backdrop-blur-md p-4" onclick="if(Date.now() - (this._lastOpenTime || 0) > 300) closeLightbox()">
+    <div id="lightbox-modal" class="hidden fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/95 backdrop-blur-md p-4" onclick="closeLightbox()">
         <!-- Close Button -->
         <button onclick="closeLightbox()" class="absolute top-4 right-4 md:top-6 md:right-6 text-white/50 hover:text-white text-3xl md:text-4xl transition-all z-[210]">
             <i class="fa-solid fa-xmark"></i>


### PR DESCRIPTION
- Removed collapsible "{n} imagenes" dropdown in TaskCards.
- Rendered image thumbnails directly in a grid for immediate access.
- Switched thumbnails from <a> tags to <div> with 'touch-action: none'.
- Implemented aggressive event suppression (stopImmediatePropagation) on pointerdown, touchstart, and click.
- Removed legacy 300ms guard in lightbox closure.
- Updated CHANGELOG.html with the new approach.