### PR TITLE
Fix duplicated icons and adjust Kanban card layout

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -147,6 +147,13 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Duplicación de Iconos en Kanban:</strong> Eliminada la duplicación de botones de acción (editar, archivar, colapsar) mediante la unificación de bloques responsivos.
+                <ul>
+                  <li>Migración de clases custom <code>.desktop-only</code>/<code>.mobile-only</code> a clases nativas de Tailwind CSS (<code>md:hidden</code>, <code>hidden md:flex</code>).</li>
+                  <li>Reubicación del botón de archivar a la parte superior derecha junto a las acciones principales.</li>
+                  <li>Optimización del layout móvil: flechas de transición de estado ahora posicionadas en los extremos laterales inferiores para mejor ergonomía táctil (<code>justify-between</code>).</li>
+                </ul>
+              </li>
               <li><strong>Layout de Tabs en Modal:</strong> Corregido error que renderizaba los tabs en vertical; ahora se fuerzan a una fila horizontal (flex-row) en todas las resoluciones.</li>
               <li><strong>Lightbox — Nuclear Minimalist Fix:</strong> Rediseño total de la interacción de imágenes en el Kanban para eliminar fricción y "clics fantasma".
                 <ul>

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -109,13 +109,13 @@ function buildTaskCard(task) {
     <i class="fa-solid fa-chevron-${isMinimized ? 'down' : 'up'}"></i>
   </button>`;
 
-  const movePrevBtn = currentColIdx > 0 ? `<button onclick="event.stopPropagation(); handleMoveCard('${task.id}', -1)" class="action-btn mobile-only text-indigo-400" title="Estado Anterior">
+  const movePrevBtn = currentColIdx > 0 ? `<button onclick="event.stopPropagation(); handleMoveCard('${task.id}', -1)" class="action-btn text-indigo-400" title="Estado Anterior">
     <i class="fa-solid fa-arrow-left"></i>
-  </button>` : '<div class="action-btn mobile-only opacity-0 pointer-events-none"></div>';
+  </button>` : '<div class="action-btn opacity-0 pointer-events-none"></div>';
 
-  const moveNextBtn = currentColIdx < KANBAN_COLUMNS.length - 1 ? `<button onclick="event.stopPropagation(); handleMoveCard('${task.id}', 1)" class="action-btn mobile-only text-emerald-400" title="Siguiente Estado">
+  const moveNextBtn = currentColIdx < KANBAN_COLUMNS.length - 1 ? `<button onclick="event.stopPropagation(); handleMoveCard('${task.id}', 1)" class="action-btn text-emerald-400" title="Siguiente Estado">
     <i class="fa-solid fa-arrow-right"></i>
-  </button>` : '<div class="action-btn mobile-only opacity-0 pointer-events-none"></div>';
+  </button>` : '<div class="action-btn opacity-0 pointer-events-none"></div>';
 
   if (isMinimized) {
     card.innerHTML = `
@@ -123,52 +123,45 @@ function buildTaskCard(task) {
       <div class="flex justify-between items-center gap-2">
         <div class="flex items-center gap-2 overflow-hidden">
           <span class="text-[9px] font-mono text-slate-500 flex-shrink-0">#${task.id}</span>
-          <div class="desktop-only flex items-center">
+          <div class="flex items-center">
             ${editBtn}
           </div>
           <p class="text-xs text-slate-200 truncate font-semibold">${task.title || task.descripcion}</p>
         </div>
         <div class="flex items-center gap-1 flex-shrink-0">
-          <div class="desktop-only flex items-center">
+          <div class="flex items-center">
             ${archiveBtn}
           </div>
           <span class="text-[8px] font-bold px-1 py-0.5 rounded ${priorityColorsMinimized[task.prioridad] || 'bg-slate-700'}">${task.prioridad[0]}</span>
           <span class="text-[8px] font-bold px-1 py-0.5 rounded ${stateInfo.color}">${stateInfo.label}</span>
-          <div class="desktop-only">
+          <div class="flex items-center">
             ${minimizeBtn}
           </div>
         </div>
       </div>
 
       <!-- Mobile-only compact actions (visible when minimized on touch) -->
-      <div class="mobile-only flex justify-between items-center mt-2 pt-2 border-t border-slate-700/50">
-        <div class="flex items-center">
-          ${movePrevBtn}
-          ${moveNextBtn}
-        </div>
-        <div class="flex items-center">
-          ${editBtn}
-          ${archiveBtn}
-          ${minimizeBtn}
-        </div>
+      <div class="md:hidden flex justify-between items-center mt-2 pt-2 border-t border-slate-700/50">
+        ${movePrevBtn}
+        ${moveNextBtn}
       </div>
     `;
   } else {
     card.innerHTML = `
-      <!-- Row 1: Meta-info & Desktop Primary Actions -->
+      <!-- Row 1: Meta-info & Primary Actions -->
       <div class="flex justify-between items-start mb-2">
         <div class="flex gap-2 items-center">
           <span class="text-[9px] font-mono text-slate-500">#${task.id}</span>
-          <div class="desktop-only">
+          <div class="flex items-center">
              ${editBtn}
           </div>
           <span class="text-[9px] font-bold px-1.5 py-0.5 rounded ${priorityColors[task.prioridad] || 'bg-slate-700'}">${task.prioridad.toUpperCase()}</span>
         </div>
         <div class="flex gap-1 items-center">
-          <div class="desktop-only flex items-center">
+          <div class="flex items-center">
             ${archiveBtn}
           </div>
-          <div class="desktop-only">
+          <div class="flex items-center">
             ${minimizeBtn}
           </div>
         </div>
@@ -191,7 +184,7 @@ function buildTaskCard(task) {
       </div>
       ` : ''}
 
-      <div class="mb-3 desktop-only">
+      <div class="mb-3 hidden md:block">
           <select onchange="event.stopPropagation(); handleQuickStageUpdate('${String(task.id)}', this.value)" class="w-full bg-slate-950/50 border border-slate-700 rounded text-[10px] p-1 text-slate-400 focus:text-white focus:border-indigo-500 outline-none">
               ${STAGES.map(s => `<option value="${s}" ${task.tema_principal === s ? 'selected' : ''}>${s}</option>`).join('')}
           </select>
@@ -235,17 +228,10 @@ function buildTaskCard(task) {
         </div>
       </div>
 
-      <!-- Row 5: Acciones SIEMPRE VISIBLES (Mobile-only) -->
-      <div class="mobile-only flex justify-between items-center mt-4 pt-2 border-t border-slate-700/50">
-        <div class="flex items-center">
-          ${movePrevBtn}
-          ${moveNextBtn}
-        </div>
-        <div class="flex items-center">
-          ${editBtn}
-          ${archiveBtn}
-          ${minimizeBtn}
-        </div>
+      <!-- Row 5: Acciones (Mobile-only) -->
+      <div class="md:hidden flex justify-between items-center mt-4 pt-2 border-t border-slate-700/50">
+        ${movePrevBtn}
+        ${moveNextBtn}
       </div>
     `;
 


### PR DESCRIPTION
Removed duplicated action icons in Kanban cards by replacing custom visibility classes with native Tailwind responsive utilities. Unified the action buttons (edit, archive, minimize) in the top row of the card and repositioned the movement arrows at the bottom edges for mobile devices to improve ergonomics.

---
*PR created automatically by Jules for task [4712559533955155776](https://jules.google.com/task/4712559533955155776) started by @Axlfc*