### PR TITLE
Visualización de Repositorios en Kanban Cards

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -78,6 +78,14 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Added</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Visualización de Repositorio en Kanban:</strong> Implementada la visualización del repositorio asignado en las tarjetas del Kanban.
+                <ul>
+                  <li><strong>Integración en Cards:</strong> El repositorio (o su alias) se muestra centrado en el footer de la card, entre las flechas de navegación, tanto en modo expandido como minimizado.</li>
+                  <li><strong>Selector Dinámico en Modal:</strong> Añadido campo "Repositorio" en la pestaña Info del modal de tareas, que se popula automáticamente con los repositorios de la organización Hypenosys vía GitHub API.</li>
+                  <li><strong>Caché de Rendimiento:</strong> Los repositorios se cargan en background una sola vez al inicializar el dashboard para garantizar una interfaz fluida.</li>
+                  <li><strong>Soporte de Alias:</strong> Integración con el sistema de alias existente para mostrar nombres amigables en lugar del nombre técnico del repo.</li>
+                </ul>
+              </li>
               <li><strong>Sincronización de Documentación:</strong> Nueva sección de Documentación que lee en tiempo real el repositorio público <code>hypenosys/docs</code>.
                 <ul>
                   <li><strong>Arquitectura Live-Sync:</strong> Integración directa con la API de GitHub para cargar y renderizar Markdown en tiempo de ejecución, eliminando la necesidad de copias manuales.</li>

--- a/_data/dashboard_tasks.json
+++ b/_data/dashboard_tasks.json
@@ -35,7 +35,8 @@
         "didac@hypenosys.com",
         "mitxel@hypenosys.com"
       ],
-      "images": []
+      "images": [],
+      "repository": null
     },
     {
       "rama": "ART",
@@ -127,7 +128,8 @@
           "old_value": "Lluvia de ideas locas sobre mecánicas, historia, modos de juego, todo vale.",
           "new_value": "Lluvia de ideas locas sobre mecánicas, historia, modos de juego, todo vale. Va al repositorio de /docs"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "DIS",
@@ -187,7 +189,8 @@
           "old_value": "chore",
           "new_value": "research"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -215,7 +218,8 @@
         "didac@hypenosys.com",
         "mitxel@hypenosys.com"
       ],
-      "images": []
+      "images": [],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -265,7 +269,8 @@
           "old_value": "feature",
           "new_value": "chore"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -291,7 +296,8 @@
       "emails_asignados": [
         "mitxel@hypenosys.com"
       ],
-      "images": []
+      "images": [],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -341,7 +347,8 @@
           "old_value": null,
           "new_value": "2026-06-30"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -413,7 +420,8 @@
           "old_value": null,
           "new_value": "2026-06-15"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -487,7 +495,8 @@
           "old_value": "[]",
           "new_value": "[\"jules\"]"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -545,7 +554,8 @@
           "old_value": "2026-06-05",
           "new_value": null
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "ART",
@@ -647,7 +657,8 @@
           "old_value": null,
           "new_value": "2026-06-05"
         }
-      ]
+      ],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -671,7 +682,8 @@
       "limite": null,
       "comentario": "",
       "id": 17,
-      "images": []
+      "images": [],
+      "repository": null
     },
     {
       "rama": "PRO",
@@ -693,7 +705,8 @@
       "apoyo": null,
       "limite": null,
       "comentario": "",
-      "id": 20
+      "id": 20,
+      "repository": null
     },
     {
       "title": "Arreglar previsualización de fotos fuera del edit",
@@ -808,7 +821,8 @@
           "new_value": "[\"24\"]"
         }
       ],
-      "id": 21
+      "id": 21,
+      "repository": null
     },
     {
       "title": "Adoptar prácticas mobile first",
@@ -891,7 +905,8 @@
           "new_value": "2026-06-05"
         }
       ],
-      "id": 22
+      "id": 22,
+      "repository": null
     },
     {
       "title": "Añadir campo repositorio a las tasks",
@@ -947,7 +962,8 @@
           "new_value": "[\"16\"]"
         }
       ],
-      "id": 23
+      "id": 23,
+      "repository": null
     },
     {
       "title": "1234",
@@ -1006,7 +1022,8 @@
           "new_value": "Obsolete"
         }
       ],
-      "id": 25
+      "id": 25,
+      "repository": null
     }
   ]
 }

--- a/assets/javascript/dashboard-data.js
+++ b/assets/javascript/dashboard-data.js
@@ -33,6 +33,7 @@ async function handleDOMContentLoaded() {
 
 async function initDashboard() {
   console.log('[DASHBOARD] Initializing Dashboard...');
+  window.userReposCache = []; // Reset/init cache
   const token = window.githubApi.getAuthToken();
   if (!token) {
     console.log('[DASHBOARD] No token found during init.');
@@ -68,6 +69,12 @@ async function initDashboard() {
     renderUserStatus(user);
     setupEventListeners();
     renderDashboard();
+
+    // Background fetch of repos
+    window.githubApi.getOrgRepos().then(repos => {
+        window.userReposCache = repos;
+        console.log('[DASHBOARD] Org repos cached:', repos.length);
+    });
 
   } catch (err) {
     console.error(err);

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -53,6 +53,7 @@ function buildTaskCard(task) {
   const hasImages = task.images && task.images.length > 0;
   const isImagesExpanded = localStorage.getItem(`task_images_expanded_${task.id}`) === 'true';
   const card = document.createElement('div');
+  card.id = `card-${task.id}`;
   card.className = `bg-slate-800 p-4 rounded-xl border border-slate-700 shadow-sm cursor-grab active:cursor-grabbing hover:border-slate-500 transition-all group relative ${isMinimized ? 'py-2' : ''}`;
   card.draggable = true;
   card.addEventListener('dragstart', e => {
@@ -117,6 +118,20 @@ function buildTaskCard(task) {
     <i class="fa-solid fa-arrow-right"></i>
   </button>` : '<div class="action-btn opacity-0 pointer-events-none"></div>';
 
+  const repoDisplay = task.repository ? (() => {
+      const fullName = task.repository;
+      const parts = fullName.split('/');
+      const shortName = parts.length > 1 ? parts.slice(1).join('/') : fullName;
+      let display = shortName;
+      if (window.getRepoDisplayName) {
+          display = window.getRepoDisplayName(fullName, shortName);
+          if (display === shortName) {
+              display = window.getRepoDisplayName(`sources/github/${fullName}`, shortName);
+          }
+      }
+      return `<span class="text-[8px] font-bold text-slate-500 uppercase tracking-tighter truncate max-w-[80px]" title="Repo: ${fullName}">${display}</span>`;
+  })() : '<span class="text-[8px] font-bold text-slate-600">—</span>';
+
   if (isMinimized) {
     card.innerHTML = `
       <!-- Desktop & Global Minimized Layout -->
@@ -141,6 +156,7 @@ function buildTaskCard(task) {
       <!-- Compact Movement Actions -->
       <div class="flex justify-between items-center mt-2 pt-2 border-t border-slate-700/50">
         ${movePrevBtn}
+        ${repoDisplay}
         ${moveNextBtn}
       </div>
     `;
@@ -227,6 +243,7 @@ function buildTaskCard(task) {
       <!-- Row 5: Movement Acciones -->
       <div class="flex justify-between items-center mt-4 pt-2 border-t border-slate-700/50">
         ${movePrevBtn}
+        ${repoDisplay}
         ${moveNextBtn}
       </div>
     `;

--- a/assets/javascript/dashboard-modals.js
+++ b/assets/javascript/dashboard-modals.js
@@ -185,6 +185,42 @@ function openAssignmentModal(taskId) {
     };
 }
 
+function populateRepoSelect() {
+    const repoSelect = document.getElementById('task-repo-input');
+    if (!repoSelect) return;
+
+    // Use cached repos
+    const repos = window.userReposCache || [];
+
+    let html = '<option value="">-- Sin asignar --</option>';
+
+    repos.forEach(repo => {
+        const fullName = repo.full_name; // owner/repo
+        const shortName = repo.name;
+        // Check if there's an alias in localStorage for this repo
+        // Note: repo-aliases.js handles this via getRepoDisplayName
+        // But the user said: "If the repo has an alias, show the alias; if not, show the short name."
+        // And for the value: "The value saved in dashboard_tasks.json must be the full name (owner/repo)"
+
+        // We use the full_name to look up alias if it exists in the project's system
+        // The project uses full_name or sources/github/owner/repo for aliases.
+        // Let's try both to be safe or just use getRepoDisplayName
+
+        let displayName = shortName;
+        if (window.getRepoDisplayName) {
+            displayName = window.getRepoDisplayName(fullName, shortName);
+            // Also try with prefix if not found
+            if (displayName === shortName) {
+                displayName = window.getRepoDisplayName(`sources/github/${fullName}`, shortName);
+            }
+        }
+
+        html += `<option value="${fullName}">${displayName}</option>`;
+    });
+
+    repoSelect.innerHTML = html;
+}
+
 function populateMemberSelects() {
     const resolverSelect = document.getElementById('task-resolver-input');
     const detectorSelect = document.getElementById('task-detector-input');

--- a/assets/javascript/dashboard-tasks.js
+++ b/assets/javascript/dashboard-tasks.js
@@ -17,6 +17,7 @@ function switchTaskModalTab(tabId) {
 function openCreateTaskModal() {
   switchTaskModalTab('info');
   populateMemberSelects();
+  populateRepoSelect();
   document.getElementById('task-modal-title').textContent = 'Crear Nueva Tarea';
   document.getElementById('task-id-input').value = '';
   document.getElementById('task-title-input').value = '';
@@ -26,6 +27,7 @@ function openCreateTaskModal() {
   document.getElementById('task-priority-input').value = 'Major';
   document.getElementById('task-milestone-input').value = 'M1';
   document.getElementById('task-topic-input').value = 'Programación / Engine';
+  document.getElementById('task-repo-input').value = '';
   document.getElementById('task-status-input').value = 'Pending';
   document.getElementById('task-completion-input').value = '0';
   document.getElementById('task-resolver-input').value = '';
@@ -66,6 +68,7 @@ function openEditTaskModal(taskId) {
 
     switchTaskModalTab('info');
     populateMemberSelects();
+    populateRepoSelect();
     document.getElementById('task-modal-title').textContent = `Editar Tarea #${taskId}`;
     document.getElementById('task-id-input').value = taskId;
     document.getElementById('task-title-input').value = task.title || '';
@@ -75,6 +78,7 @@ function openEditTaskModal(taskId) {
     document.getElementById('task-priority-input').value = task.prioridad || 'Major';
     document.getElementById('task-milestone-input').value = task.milestone || 'M1';
     document.getElementById('task-topic-input').value = task.tema_principal || 'Programación / Engine';
+    document.getElementById('task-repo-input').value = task.repository || '';
     let status = task.estado || 'Pending';
     if (status === '?') status = 'In Review';
     document.getElementById('task-status-input').value = status;
@@ -134,6 +138,7 @@ async function handleCreateTask() {
   const priority = document.getElementById('task-priority-input').value;
   const milestone = document.getElementById('task-milestone-input').value;
   const topic = document.getElementById('task-topic-input').value;
+  const repository = document.getElementById('task-repo-input').value || null;
   const status = document.getElementById('task-status-input').value;
   const completion = parseFloat(document.getElementById('task-completion-input').value) || 0;
   const resolver = document.getElementById('task-resolver-input').value || null;
@@ -158,6 +163,7 @@ async function handleCreateTask() {
     rama,
     task_type: taskType,
     tema_principal: topic,
+    repository: repository,
     prioridad: priority,
     milestone,
     estado: status,
@@ -481,7 +487,7 @@ function closeLightbox() {
 
 
 function diffTasks(oldTask, newTask) {
-    const fields = ['title', 'descripcion', 'estado', 'prioridad', 'milestone', 'asignados', 'blocks', 'blocked_by', 'due_date', 'task_type', 'tags', 'completitud'];
+    const fields = ['title', 'descripcion', 'estado', 'prioridad', 'milestone', 'asignados', 'blocks', 'blocked_by', 'due_date', 'task_type', 'tags', 'completitud', 'repository'];
     const changes = [];
     const timestamp = new Date().toISOString();
     const author = window.currentUser || 'Unknown';

--- a/assets/javascript/github-api.js
+++ b/assets/javascript/github-api.js
@@ -484,6 +484,30 @@ async function restoreTask(taskId) {
   });
 }
 
+async function getOrgRepos() {
+  try {
+    const token = getAuthToken();
+    if (!token) return [];
+
+    const resp = await fetch(`${GITHUB_API_BASE}/orgs/${REPO_OWNER}/repos?per_page=100`, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github.v3+json'
+      }
+    });
+
+    if (!resp.ok) {
+      console.warn('[GITHUB-API] Error fetching org repos:', resp.status);
+      return [];
+    }
+
+    return await resp.json();
+  } catch (err) {
+    console.error('[GITHUB-API] Error in getOrgRepos:', err);
+    return [];
+  }
+}
+
 async function updateMemberProfile(memberName, profileDelta) {
   // 1. Update team_profiles.json
   await atomicWrite('_data/team_profiles.json', (db) => {
@@ -656,6 +680,7 @@ window.githubApi = {
   archiveTask,
   restoreTask,
   updateBudget,
+  getOrgRepos,
   updateMemberProfile,
   recomputeAndSaveStats,
   deleteFile,

--- a/dashboard.html
+++ b/dashboard.html
@@ -473,6 +473,12 @@
                             </select>
                         </div>
                         <div>
+                            <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Repositorio</label>
+                            <select id="task-repo-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">
+                                <option value="">-- Sin asignar --</option>
+                            </select>
+                        </div>
+                        <div>
                             <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Tema Principal (Stage)</label>
                             <select id="task-topic-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100">
                                 <option value="Concepto / GDD">Concepto / GDD</option>


### PR DESCRIPTION
Esta funcionalidad permite visualizar y asignar repositorios a las tareas del Kanban.

### Cambios realizados:
1. **GitHub API:** Nueva función para listar repositorios de la organización Hypenosys.
2. **Dashboard Data:** Los repositorios se cargan una sola vez al inicio y se mantienen en una caché global para óptimo rendimiento.
3. **Modal de Tareas:** Nuevo campo desplegable en la pestaña "Info" para asignar un repositorio. Soporta alias locales.
4. **Kanban Cards:** Visualización del repositorio (alias o nombre corto) en el footer de la tarjeta, integrada armoniosamente con las flechas de movimiento.
5. **Schema:** El campo `repository` se guarda en la raíz de cada objeto de tarea.
6. **Persistence:** Se asegura la persistencia del campo tanto en la creación como en la edición de tareas.

Visualmente verificado con Playwright.

---
*PR created automatically by Jules for task [6649169423095094691](https://jules.google.com/task/6649169423095094691) started by @Axlfc*