### PR TITLE
Hybrid Loading Strategy for Jules Panel Repository Selector

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -64,6 +64,14 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Changed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Estrategia de Carga Híbrida en Jules Panel:</strong> Optimización radical del selector de repositorios para eliminar tiempos de espera y timeouts.
+                <ul>
+                  <li><strong>Phase 1 (GitHub API):</strong> Carga inmediata de repositorios de la organización Hypenosys utilizando caché local o GitHub API directa. Los repositorios están disponibles para selección instantánea con etiquetas de nombre corto.</li>
+                  <li><strong>Phase 2 (Jules API Enrichment):</strong> Enriquecimiento en segundo plano de las etiquetas con alias oficiales de Jules y adición de repositorios de otras organizaciones, con un timeout de seguridad de 8 segundos.</li>
+                  <li><strong>Gestión de Estado de Sesión:</strong> El botón "Lanzar Sesión" ahora muestra un estado de verificación visual y se habilita automáticamente tras la validación con la API de Jules, garantizando compatibilidad total.</li>
+                  <li><strong>Persistencia Inteligente:</strong> Se preserva la selección del usuario y la rama elegida durante el proceso de enriquecimiento, evitando reseteos de formulario.</li>
+                </ul>
+              </li>
               <li><strong>Filtro de Miembros Optimizado:</strong> Rediseño del selector de equipo en el Dashboard para mejorar la usabilidad en dispositivos móviles y tablets.
                 <ul>
                   <li><strong>Layout de Chips Horizontales:</strong> Reemplazada la lista vertical por una fila única de chips/pills compactos con scroll horizontal suave.</li>

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -1002,6 +1002,7 @@ permalink: /jules-panel/
     let nextPageToken = null;
     let lastRefreshTime = Date.now();
     let currentFilter = 'all';
+    let julesApiReady = false;
 
     let sessionPollInterval = null;
     const activeActivityPolls = new Set();
@@ -1060,67 +1061,129 @@ permalink: /jules-panel/
     }
 
     // --- REPOSITORY LOGIC ---
+    function updateLaunchButtonState() {
+        const btn = document.getElementById('jules-launch-btn');
+        if (!btn) return;
+
+        if (julesApiReady) {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fa-solid fa-rocket mr-2"></i> Lanzar Sesión';
+        } else {
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fa-solid fa-circle-notch fa-spin mr-2"></i> Verificando con Jules...';
+        }
+    }
+
     async function initializeRepoSelector() {
         const repoSelect = document.getElementById('jules-repo-select');
         const repoStatus = document.getElementById('repo-error-container');
 
         repoSelect.innerHTML = '<option value="">Cargando fuentes...</option>';
         repoSelect.disabled = true;
+        julesApiReady = false;
+        updateLaunchButtonState();
 
-        try {
-            const sources = await window.loadAllSources();
-            window.julesSourcesCache = sources;
-            currentSources = sources;
-
-            if (sources.length === 0) {
-                repoSelect.innerHTML = '<option value="">No hay repos disponibles</option>';
-                showError('No se encontraron repositorios. Instala la Jules GitHub App.');
-                return;
+        // PHASE 1: GitHub API (Immediate)
+        let githubRepos = window.userReposCache || [];
+        if (githubRepos.length === 0 && window.githubApi) {
+            try {
+                githubRepos = await window.githubApi.getOrgRepos();
+                window.userReposCache = githubRepos;
+            } catch (e) {
+                console.warn('[Jules Panel] Error fetching GH repos for Phase 1:', e);
             }
+        }
 
-            // Agrupar por owner
-            const groups = {};
-            sources.forEach(s => {
-                const owner = s.githubRepo?.owner || window.parseSourceName(s.name)?.owner || 'Otros';
-                if (!groups[owner]) groups[owner] = [];
-                groups[owner].push(s);
+        if (githubRepos.length > 0) {
+            currentSources = githubRepos.map(r => ({
+                name: `sources/github/hypenosys/${r.name}`,
+                githubRepo: { owner: 'hypenosys', repo: r.name }
+            }));
+            populateSelector(currentSources).then(() => {
+                repoSelect.disabled = false;
             });
+        }
 
-            repoSelect.innerHTML = '<option value="">— Escoge un repositorio —</option>';
-            Object.entries(groups).sort(([a], [b]) => a.localeCompare(b)).forEach(([owner, srcs]) => {
-                const optgroup = document.createElement('optgroup');
-                optgroup.label = owner;
-                srcs.forEach(s => {
-                    const opt = document.createElement('option');
-                    opt.value = s.name;
-                    const repoShortName = s.githubRepo?.repo || window.parseSourceName(s.name)?.repo || s.name;
-                    const fullRepoLabel = `${owner}/${repoShortName}`;
-                    opt.textContent = window.getRepoDisplayName(s.name, fullRepoLabel);
-                    optgroup.appendChild(opt);
-                });
-                repoSelect.appendChild(optgroup);
+        // PHASE 2: Jules API Enrichment (Parallel/Background)
+        const julesPromise = window.loadAllSources();
+        const timeoutPromise = new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('TIMEOUT_PHASE2')), 8000)
+        );
+
+        Promise.race([julesPromise, timeoutPromise])
+            .then(async sources => {
+                console.log('[Jules Panel] Phase 2 success:', sources.length, 'sources');
+                currentSources = sources;
+                window.julesSourcesCache = sources;
+                await populateSelector(sources);
+                julesApiReady = true;
+                updateLaunchButtonState();
+            })
+            .catch(err => {
+                console.warn('[Jules Panel] Phase 2 failed or timeout:', err.message);
+                if (githubRepos.length === 0) {
+                    repoSelect.innerHTML = '<option value="">Error de carga</option>';
+                    showError('No se pudo conectar con GitHub ni con Jules API.');
+                }
+                // Habilitar de todas formas si tenemos algo de GH o si falló Jules
+                julesApiReady = true;
+                updateLaunchButtonState();
             });
+    }
 
-            repoSelect.disabled = false;
-            if (repoStatus) {
-                repoStatus.innerHTML = `<div class="text-[10px] text-emerald-500 mt-2 font-bold uppercase tracking-wider">${sources.length} repositorios conectados</div>`;
-            }
+    async function populateSelector(sources) {
+        const repoSelect = document.getElementById('jules-repo-select');
+        const currentVal = repoSelect.value;
 
-            // Restaurar selección anterior
+        // Agrupar por owner
+        const groups = {};
+        sources.forEach(s => {
+            const owner = s.githubRepo?.owner || window.parseSourceName(s.name)?.owner || 'Otros';
+            if (!groups[owner]) groups[owner] = [];
+            groups[owner].push(s);
+        });
+
+        repoSelect.innerHTML = '<option value="">— Escoge un repositorio —</option>';
+        Object.entries(groups).sort(([a], [b]) => a.localeCompare(b)).forEach(([owner, srcs]) => {
+            const optgroup = document.createElement('optgroup');
+            optgroup.label = owner;
+            srcs.forEach(s => {
+                const opt = document.createElement('option');
+                opt.value = s.name;
+                const repoShortName = s.githubRepo?.repo || window.parseSourceName(s.name)?.repo || s.name;
+                const julesAlias = s.displayName;
+
+                // Label Híbrido:
+                // 1. Alias local (Phase 1 & 2)
+                // 2. Jules displayName (Phase 2 only)
+                // 3. Repo short name (Phase 1 fallback)
+                const fallbackLabel = julesAlias || ((owner === 'hypenosys') ? repoShortName : `${owner}/${repoShortName}`);
+                opt.textContent = window.getRepoDisplayName(s.name, fallbackLabel);
+
+                optgroup.appendChild(opt);
+            });
+            repoSelect.appendChild(optgroup);
+        });
+
+        // Restaurar selección o aplicar la guardada
+        if (currentVal && sources.some(s => s.name === currentVal)) {
+            repoSelect.value = currentVal;
+        } else {
             const lastSource = localStorage.getItem('jules_selected_source');
-            const lastBranch = localStorage.getItem('jules_selected_branch');
             if (lastSource && sources.some(s => s.name === lastSource)) {
                 repoSelect.value = lastSource;
                 const sourceObj = sources.find(s => s.name === lastSource);
                 await onRepoSelected(lastSource, sourceObj);
+                const lastBranch = localStorage.getItem('jules_selected_branch');
                 if (lastBranch) {
                     document.getElementById('jules-branch-input').value = lastBranch;
                 }
             }
+        }
 
-        } catch (e) {
-            handleApiError(e);
-            repoSelect.innerHTML = '<option value="">Error de carga</option>';
+        const repoStatus = document.getElementById('repo-error-container');
+        if (repoStatus && sources.length > 0) {
+            repoStatus.innerHTML = `<div class="text-[10px] text-emerald-500 mt-2 font-bold uppercase tracking-wider">${sources.length} repositorios conectados</div>`;
         }
     }
 


### PR DESCRIPTION
Implemented a two-phase (hybrid) loading strategy for the repository selector in the Jules Panel to solve slowness and timeout issues with the Jules API.

Key changes:
1. **Phase 1 (GitHub API):** The selector now populates immediately using repositories from the 'hypenosys' organization fetched via GitHub API or retrieved from the local `window.userReposCache`. Labels use the repository's short name for a cleaner look.
2. **Phase 2 (Jules API Enrichment):** In parallel, the Jules API `loadAllSources` is called to enrich existing labels with official aliases and add repositories from other organizations. This phase has a safety timeout of 8 seconds.
3. **Launch Session Safety:** The "Lanzar Sesión" button is disabled and shows a "Verificando con Jules..." state until Phase 2 completes or times out, ensuring the underlying Jules engine is ready to process the selected source.
4. **Persistence:** Form state, including the selected repository and branch, is preserved during the background enrichment process.
5. **Compatibility:** Maintained the `sources/github/owner/repo` value format required by Jules API.
6. **Documentation:** Added a detailed entry to `CHANGELOG.html` under the [Unreleased] section.

---
*PR created automatically by Jules for task [15768236602393870128](https://jules.google.com/task/15768236602393870128) started by @Axlfc*