### PR TITLE
Fix Jules Panel "Verificando credenciales..." hang

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -163,6 +163,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-danger">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Auth Hang en Jules Panel:</strong> Corregido error de sintaxis en <code>jules-panel.html</code> que bloqueaba la ejecución del script de autenticación y dejaba el panel atascado en "Verificando credenciales...".</li>
               <li><strong>Duplicación de Iconos en Kanban:</strong> Eliminada la duplicación de botones de acción (editar, archivar, colapsar) mediante la unificación de bloques responsivos.
                 <ul>
                   <li>Migración de clases custom <code>.desktop-only</code>/<code>.mobile-only</code> a clases nativas de Tailwind CSS (<code>md:hidden</code>, <code>hidden md:flex</code>).</li>

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -1155,7 +1155,6 @@ permalink: /jules-panel/
                 const mr = ms.githubRepo?.repo || window.parseSourceName(ms.name)?.repo;
                 return mo === owner && mr === repo;
             });
-    }
 
             if (existingIdx >= 0) {
                 // Update with Jules data (keeping compatibility)


### PR DESCRIPTION
I have fixed the "Verificando credenciales..." hang in the Jules Panel. The issue was a stray closing brace `}` in the `processJulesEnrichment` function in `pages/jules-panel.html` that broke the script's execution.

Key changes:
1. Removed the stray brace in `pages/jules-panel.html`.
2. Verified the fix by running a Playwright script that confirms the loading screen disappears and shows the next state (Auth Gate or Panel).
3. Updated `CHANGELOG.html` to document the fix.

The hybrid loading logic and auth flow remain unchanged, but they are now able to execute correctly.

---
*PR created automatically by Jules for task [5705238691861721360](https://jules.google.com/task/5705238691861721360) started by @Axlfc*