### PR TITLE
Use repository aliases in Dashboard modal and Kanban cards

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -62,6 +62,14 @@ permalink: /CHANGELOG.html
         <h2 class="text-purple border-bottom border-purple pb-2 mb-4">[Unreleased]</h2>
         <div class="card mb-3">
           <div class="card-body">
+            <h5 class="text-success">Added</h5>
+            <ul class="tree-view mb-3">
+              <li><strong>Aliases de Repositorios en Dashboard:</strong> Implementada la visualización de aliases personalizados en el modal de tareas y en el footer de las Kanban cards.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="card mb-3">
+          <div class="card-body">
             <h5 class="text-success">Changed</h5>
             <ul class="tree-view mb-3">
               <li><strong>Estrategia de Carga Híbrida en Jules Panel:</strong> Optimización radical del selector de repositorios para eliminar tiempos de espera y timeouts.

--- a/assets/javascript/dashboard-modals.js
+++ b/assets/javascript/dashboard-modals.js
@@ -197,23 +197,9 @@ function populateRepoSelect() {
     repos.forEach(repo => {
         const fullName = repo.full_name; // owner/repo
         const shortName = repo.name;
-        // Check if there's an alias in localStorage for this repo
-        // Note: repo-aliases.js handles this via getRepoDisplayName
-        // But the user said: "If the repo has an alias, show the alias; if not, show the short name."
-        // And for the value: "The value saved in dashboard_tasks.json must be the full name (owner/repo)"
 
-        // We use the full_name to look up alias if it exists in the project's system
-        // The project uses full_name or sources/github/owner/repo for aliases.
-        // Let's try both to be safe or just use getRepoDisplayName
-
-        let displayName = shortName;
-        if (window.getRepoDisplayName) {
-            displayName = window.getRepoDisplayName(fullName, shortName);
-            // Also try with prefix if not found
-            if (displayName === shortName) {
-                displayName = window.getRepoDisplayName(`sources/github/${fullName}`, shortName);
-            }
-        }
+        // Use getRepoDisplayName to get alias if exists, otherwise fallback to shortName
+        const displayName = window.getRepoDisplayName ? window.getRepoDisplayName(fullName, shortName) : shortName;
 
         html += `<option value="${fullName}">${displayName}</option>`;
     });

--- a/dashboard.html
+++ b/dashboard.html
@@ -896,6 +896,7 @@
     <!-- Scripts -->
     <script src="assets/javascript/github-api.js"></script>
     <script src="assets/javascript/ui-components.js"></script>
+    <script src="assets/javascript/repo-aliases.js"></script>
 
     <!-- Dashboard Modular Architecture -->
     <script src="assets/javascript/dashboard-config.js"></script>


### PR DESCRIPTION
This change integrates the repository alias system (already used in the Jules Panel) into the main Dashboard. 

Key changes:
1. **Script Inclusion**: Added `repo-aliases.js` to `dashboard.html` before other dashboard scripts.
2. **Task Modal**: Updated the repository dropdown in `dashboard-modals.js` to use `getRepoDisplayName` for labels. The value remains the full repository name to ensure data compatibility.
3. **Kanban Cards**: Confirmed that `dashboard-kanban.js` already uses `getRepoDisplayName` and verified it works correctly now that the script is included.
4. **Changelog**: Added a new entry for these changes in the `[Unreleased]` section.

Verified via Playwright script with mocked GitHub API responses.

---
*PR created automatically by Jules for task [7691572096560565770](https://jules.google.com/task/7691572096560565770) started by @Axlfc*