### PR TITLE
Reorder Kanban Card Header Elements

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -72,6 +72,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Changed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>UI de Kanban Cards:</strong> Reordenados los elementos de la cabecera de las tarjetas para mejorar el flujo de lectura. El botón de edición se ha movido a la izquierda, junto al ID de la tarea, mientras que las acciones de archivo y colapso se mantienen a la derecha.</li>
               <li><strong>Estrategia de Carga Híbrida en Jules Panel:</strong> Optimización radical del selector de repositorios para eliminar tiempos de espera y timeouts.
                 <ul>
                   <li><strong>Phase 1 (GitHub API):</strong> Carga inmediata de repositorios de la organización Hypenosys utilizando caché local o GitHub API directa. Los repositorios están disponibles para selección instantánea con etiquetas de nombre corto.</li>

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -132,11 +132,11 @@ function buildTaskCard(task) {
       <div class="flex justify-between items-center gap-2">
         <div class="flex items-center gap-2 overflow-hidden">
           <span class="text-[9px] font-mono text-slate-500 flex-shrink-0">#${task.id}</span>
+          ${editBtn}
           <p class="text-xs text-slate-200 truncate font-semibold">${task.title || task.descripcion}</p>
         </div>
         <div class="flex items-center gap-1 flex-shrink-0">
           <div class="flex items-center">
-            ${editBtn}
             ${archiveBtn}
           </div>
           <span class="text-[8px] font-bold px-1 py-0.5 rounded ${priorityColorsMinimized[task.prioridad] || 'bg-slate-700'}">${task.prioridad[0]}</span>
@@ -160,11 +160,11 @@ function buildTaskCard(task) {
       <div class="flex justify-between items-start mb-2">
         <div class="flex gap-2 items-center">
           <span class="text-[9px] font-mono text-slate-500">#${task.id}</span>
+          ${editBtn}
           <span class="text-[9px] font-bold px-1.5 py-0.5 rounded ${priorityColors[task.prioridad] || 'bg-slate-700'}">${task.prioridad.toUpperCase()}</span>
         </div>
         <div class="flex gap-1 items-center">
           <div class="flex items-center">
-            ${editBtn}
             ${archiveBtn}
           </div>
           <div class="flex items-center">


### PR DESCRIPTION
Reordered header elements in `buildTaskCard` function within `assets/javascript/dashboard-kanban.js` to move the edit icon to the left, immediately after the task ID. The right side now only contains the archive and collapse/expand buttons, maintaining the desired layout for both expanded and minimized cards. Updated CHANGELOG.html accordingly.

---
*PR created automatically by Jules for task [4910874218075698319](https://jules.google.com/task/4910874218075698319) started by @Axlfc*