### PR TITLE
fix(auth): resolve race condition and double-flash in dashboard

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -62,6 +62,22 @@ permalink: /CHANGELOG.html
         <h2 class="text-purple border-bottom border-purple pb-2 mb-4">[Unreleased]</h2>
         <div class="card mb-3">
           <div class="card-body">
+            <h5 class="text-success">Fixed</h5>
+            <ul class="tree-view mb-0">
+              <li><strong>Sincronización Crítica de Auth (Dashboard):</strong> Eliminación definitiva de condiciones de carrera (race conditions) entre <code>auth.js</code> y <code>dashboard-data.js</code> mediante la implementación de un flujo dirigido por eventos.
+                <ul>
+                  <li><strong>Event-Driven Bootstrapping:</strong> El dashboard ahora espera exclusivamente al evento <code>authReady</code> emitido por <code>AuthManager</code> antes de intentar cargar datos de la API de GitHub.</li>
+                  <li><strong>Mecanismo Failsafe:</strong> Implementado un timeout de seguridad de 3 segundos que fuerza la inicialización manual si el gestor global falla, garantizando que el dashboard nunca se quede bloqueado.</li>
+                  <li><strong>Inclusión Global de Auth:</strong> Añadido <code>auth.js</code> a <code>dashboard.html</code> para unificar el estado de sesión con el resto del sitio y permitir delegación correcta de <code>handleDashboardLogin()</code>.</li>
+                  <li><strong>Guard de Inicialización:</strong> Introducida la variable <code>window._dashboardInitialized</code> para prevenir dobles cargas o estados inconsistentes durante el arranque.</li>
+                  <li><strong>Guard de Ruta (isDashboard):</strong> <code>AuthManager</code> ahora evita validaciones activas en el dashboard para delegar el control y eliminar parpadeos visuales (double-flash).</li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="card mb-3">
+          <div class="card-body">
             <h5 class="text-danger">Emergency Rollback & Lock</h5>
             <ul class="tree-view mb-0">
               <li><strong>Stable Auth Restoration:</strong> Reverted `auth.js`, `dashboard-data.js`, `github-api.js`, and `dashboard.html` to their exact state in commit `3d5b28f`.</li>

--- a/assets/javascript/auth.js
+++ b/assets/javascript/auth.js
@@ -11,8 +11,17 @@ class AuthManager {
     async init() {
         this.bindEvents();
 
-        // Skip OAuth callback if we're on dashboard.html and it already handled it?
-        // Actually, better to centralize here.
+        // Si estamos en el dashboard, delegamos el control de la autenticación
+        // a dashboard-data.js para evitar conflictos y parpadeos (double-flash).
+        const isDashboard = window.location.pathname.includes('dashboard');
+        if (isDashboard) {
+            console.log('[AUTH] Dashboard detected. Delegating auth control to dashboard-data.js');
+            document.dispatchEvent(new CustomEvent('authReady', {
+                detail: { user: window.githubApi.user || null }
+            }));
+            return;
+        }
+
         await this.handleOAuthCallback();
         await this.checkAuthState();
         

--- a/assets/javascript/dashboard-data.js
+++ b/assets/javascript/dashboard-data.js
@@ -32,6 +32,7 @@ async function handleDOMContentLoaded() {
 }
 
 async function initDashboard() {
+  window._dashboardInitialized = true;
   console.log('[DASHBOARD] Initializing Dashboard...');
   window.userReposCache = []; // Reset/init cache
   const token = window.githubApi.getAuthToken();
@@ -201,4 +202,17 @@ async function refreshDashboardData() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', handleDOMContentLoaded);
+document.addEventListener('authReady', async (e) => {
+    console.log('[DASHBOARD] authReady received. Starting initialization...');
+    await handleDOMContentLoaded();
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    // If authManager failed to fire authReady for any reason, fallback
+    setTimeout(() => {
+        if (!window._dashboardInitialized) {
+            console.warn('[DASHBOARD] authReady timeout. Falling back to manual check...');
+            handleDOMContentLoaded();
+        }
+    }, 3000);
+});

--- a/dashboard.html
+++ b/dashboard.html
@@ -896,6 +896,7 @@
     <!-- Scripts -->
     <script src="assets/javascript/github-api.js"></script>
     <script src="assets/javascript/ui-components.js"></script>
+    <script src="assets/javascript/auth.js"></script>
     <script src="assets/javascript/repo-aliases.js"></script>
 
     <!-- Dashboard Modular Architecture -->


### PR DESCRIPTION
- Added `isDashboard` guard in `AuthManager.init()` to delegate auth control on dashboard pages.
- Fixed regression in `dashboard-data.js` to ensure `handleDOMContentLoaded` is called upon `authReady`.
- Updated `CHANGELOG.html` with details of the fix.