### PR TITLE
Fix Dashboard Avatar, Session Restoration, and Dream Team Hang

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "/tmp/vendor/bundle"

--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -64,6 +64,13 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul class="tree-view mb-0">
+              <li><strong>Surgical Fixes (Ops Dashboard & Landing):</strong> Resolución de 3 bugs específicos tras el rollback de autenticación.
+                <ul>
+                  <li><strong>Avatar del Dashboard:</strong> Restaurada la visualización del avatar y nombre del usuario en el header (desktop y mobile) mediante la vinculación correcta con <code>HypenosysUI</code> y llamadas explícitas post-inicialización.</li>
+                  <li><strong>Persistencia de Sesión:</strong> Implementada la restauración proactiva de sesión al cargar el dashboard, validando tokens existentes en <code>localStorage</code>/<code>sessionStorage</code> antes de la carga de datos.</li>
+                  <li><strong>Dream Team (Landing):</strong> Restaurado el renderizado estático (Jekyll build-time) de la sección de equipo, eliminando el cuelgue en "Conectando..." causado por fallos en el fetch runtime.</li>
+                </ul>
+              </li>
               <li><strong>Sincronización Crítica de Auth (Dashboard):</strong> Eliminación definitiva de condiciones de carrera (race conditions) entre <code>auth.js</code> y <code>dashboard-data.js</code> mediante la implementación de un flujo dirigido por eventos.
                 <ul>
                   <li><strong>Event-Driven Bootstrapping:</strong> El dashboard ahora espera exclusivamente al evento <code>authReady</code> emitido por <code>AuthManager</code> antes de intentar cargar datos de la API de GitHub.</li>

--- a/_includes/team_section.html
+++ b/_includes/team_section.html
@@ -1,26 +1,32 @@
-<script>
-document.addEventListener('DOMContentLoaded', async () => {
-    // We wait for window.githubApi to be ready (it's loaded at the end of footer.html)
-    // Actually, AuthManager handles the first render via renderDreamTeamComponent()
-    // if the container #dream-team-container exists.
-    
-    // Check if it's already rendered, if not, trigger it when auth is ready
-    if (window.authManager) {
-        window.authManager.renderDreamTeamComponent();
-    } else {
-        document.addEventListener('authReady', () => {
-            window.authManager.renderDreamTeamComponent();
-        });
-    }
-});
-</script>
-
 <div class="row" id="dream-team-container">
-    <!-- Team cards rendered at runtime from team_profiles.json -->
-    <div class="col-12 text-center py-5">
-        <div class="spinner-border text-purple" role="status">
-            <span class="sr-only">Cargando equipo...</span>
+    {% for member in site.data.team %}
+    <div class="col-lg-4 col-md-6 mb-4">
+        <div class="card h-100 team-card shadow-sm">
+            <div class="team-img-container">
+                <img src="{{ member.image | relative_url }}" class="card-img-top team-img" alt="{{ member.name }}">
+            </div>
+            <div class="card-body d-flex flex-column">
+                <h4 class="card-title text-purple font-weight-bold">{{ member.name | upcase }}</h4>
+                <div class="role-tag mb-3 small">{{ member.role }}</div>
+                <p class="card-text flex-grow-1 text-light">{{ member.description }}</p>
+                <div class="mt-3">
+                    {% for skill in member.skills %}
+                    <span class="badge badge-skill mr-1 mb-1">{{ skill }}</span>
+                    {% endfor %}
+                </div>
+                <div class="mt-4 pt-3 border-top border-dark d-flex flex-wrap">
+                    {% if member.github %}
+                    <a href="{{ member.github }}" class="btn btn-sm btn-outline-purple mr-2 mb-2" target="_blank">GitHub</a>
+                    {% endif %}
+                    {% if member.portfolio %}
+                    <a href="{{ member.portfolio }}" class="btn btn-sm btn-outline-purple mr-2 mb-2" target="_blank">Portfolio</a>
+                    {% endif %}
+                    {% for link in member.extra_links %}
+                    <a href="{{ link.url }}" class="btn btn-sm btn-outline-purple mr-2 mb-2" target="_blank">{{ link.name }}</a>
+                    {% endfor %}
+                </div>
+            </div>
         </div>
-        <p class="mt-2 text-muted small uppercase">Conectando con la base de datos de Hypenosys...</p>
     </div>
+    {% endfor %}
 </div>

--- a/assets/javascript/auth.js
+++ b/assets/javascript/auth.js
@@ -94,9 +94,6 @@ class AuthManager {
             const result = await window.githubApi.validateToken();
             if (result.valid) {
                 this.updateHeaderUI(result.user);
-                if (document.getElementById('dream-team-container')) {
-                    await this.renderDreamTeamComponent();
-                }
             } else {
                 this.handleAuthError({
                     status: result.user ? 403 : 401,

--- a/assets/javascript/dashboard-data.js
+++ b/assets/javascript/dashboard-data.js
@@ -179,6 +179,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             window.history.replaceState({}, document.title, window.location.pathname);
             if (result.valid) {
                 await initDashboard();
+                // BUG 1 Fix: Explicit call after initDashboard
+                renderUserStatus(result.user);
             } else {
                 throw new Error('No autorizado');
             }
@@ -189,12 +191,38 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (loginOverlay) loginOverlay.classList.remove('hidden');
         }
     } else {
-        // No code — wait for authReady from auth.js, then init
-        document.addEventListener('authReady', async () => {
-            console.log('[DASHBOARD] authReady received. Starting initialization...');
-            if (!window._dashboardInitialized) {
-                await initDashboard();
+        // Proactive session restoration
+        const token = window.githubApi.getAuthToken();
+        if (token) {
+            console.log('[DASHBOARD] Existing token found. Validating...');
+            try {
+                const { valid, user } = await window.githubApi.validateToken();
+                if (valid) {
+                    await initDashboard();
+                    // BUG 1 Fix: Ensure renderUserStatus is called after initDashboard
+                    renderUserStatus(user);
+                } else {
+                    console.warn('[DASHBOARD] Session restoration failed validation.');
+                    document.getElementById('login-overlay').classList.remove('hidden');
+                }
+            } catch (err) {
+                console.error('[DASHBOARD] Session restoration error:', err);
+                document.getElementById('login-overlay').classList.remove('hidden');
             }
-        });
+        } else {
+            // No code, no token — wait for authReady as fallback
+            document.addEventListener('authReady', async (event) => {
+                console.log('[DASHBOARD] authReady received. Starting initialization...');
+                if (!window._dashboardInitialized) {
+                    await initDashboard();
+                    // BUG 1 Fix: Explicit call after initDashboard
+                    if (event.detail && event.detail.user) {
+                        renderUserStatus(event.detail.user);
+                    } else if (window.githubApi.user) {
+                        renderUserStatus(window.githubApi.user);
+                    }
+                }
+            });
+        }
     }
 });

--- a/assets/javascript/dashboard-ui.js
+++ b/assets/javascript/dashboard-ui.js
@@ -381,9 +381,28 @@ function updateJulesBadges() {
 }
 
 function renderUserStatus(user) {
-  // Handled by AuthManager.updateHeaderUI in unified system
-  if (window.authManager) {
-    window.authManager.updateHeaderUI(user);
+  if (!user) return;
+
+  const desktop = document.getElementById('user-status');
+  const mobile = document.getElementById('user-status-mobile');
+
+  const avatarHtml = window.HypenosysUI.renderAvatar(user);
+
+  if (desktop) {
+    desktop.innerHTML = `
+      <span class="text-xs font-bold text-slate-400 hidden xl:inline">${user.login}</span>
+      <div class="cursor-pointer" onclick="window.authManager.showProfileModal()">
+        ${avatarHtml}
+      </div>
+    `;
+  }
+
+  if (mobile) {
+    mobile.innerHTML = `
+      <div class="cursor-pointer" onclick="window.authManager.showProfileModal()">
+        ${avatarHtml}
+      </div>
+    `;
   }
 }
 


### PR DESCRIPTION
This PR addresses three specific bugs:
1. Missing User Avatar: The dashboard now correctly renders the user's GitHub avatar in both desktop and mobile headers immediately after login or session restoration.
2. Session Restoration: Users are no longer logged out on page refresh; the dashboard proactively validates existing tokens in storage.
3. Dream Team Hang: The landing page team section now uses robust, static Jekyll build-time rendering, eliminating runtime fetch errors.

All changes are surgical and respect existing OAuth and data structures.

---
*PR created automatically by Jules for task [10238638525309844695](https://jules.google.com/task/10238638525309844695) started by @Axlfc*