### PR TITLE
Fix Jules Panel Repository Selector and Branch Loading

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -128,6 +128,14 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Jules Panel Selector & Branch Loading:</strong>
+                <ul>
+                  <li>Corregido bug donde el selector de repositorio no actualizaba el repositorio activo al hacer clic.</li>
+                  <li>Restaurada la carga automática de ramas al cambiar a cualquier repositorio, incluyendo repositorios personales.</li>
+                  <li>Implementado agrupamiento dinámico en el selector: HYPENOSYS (primero), otros propietarios (alfabéticamente) y usuario autenticado (al final).</li>
+                  <li>Actualizada la infraestructura de <code>github-context.js</code> para soportar múltiples propietarios (multi-owner) de forma nativa.</li>
+                </ul>
+              </li>
               <li><strong>Critical Auth & Jules Panel Fixes:</strong>
                 <ul>
                   <li>Corregido crash "Cannot set properties of null" en Jules Panel mediante la implementación de los elementos HTML del Custom Dropdown.</li>

--- a/assets/javascript/github-context.js
+++ b/assets/javascript/github-context.js
@@ -151,16 +151,16 @@
         },
 
         /**
-         * getBranches(repo)
+         * getBranches(repo, owner)
          */
-        getBranches: async (repoName) => {
-            const key = `branches_${repoName}`;
-            const url = `${GITHUB_API_BASE}/repos/${ORG_NAME}/${repoName}/branches?per_page=100`;
+        getBranches: async (repoName, owner = ORG_NAME) => {
+            const key = `branches_${owner}_${repoName}`;
+            const url = `${GITHUB_API_BASE}/repos/${owner}/${repoName}/branches?per_page=100`;
             const branches = await fetchWithCache(key, url);
 
             // Fetch last commit for each branch in parallel
             return await Promise.all(branches.map(async b => {
-                const commitInfo = await githubContext.getCommit(repoName, b.commit.sha);
+                const commitInfo = await githubContext.getCommit(repoName, b.commit.sha, owner);
                 return {
                     name: b.name,
                     protected: b.protected,
@@ -175,20 +175,20 @@
         },
 
         /**
-         * getCommit(repo, sha)
+         * getCommit(repo, sha, owner)
          */
-        getCommit: async (repoName, sha) => {
-            const key = `commit_${repoName}_${sha}`;
-            const url = `${GITHUB_API_BASE}/repos/${ORG_NAME}/${repoName}/commits/${sha}`;
+        getCommit: async (repoName, sha, owner = ORG_NAME) => {
+            const key = `commit_${owner}_${repoName}_${sha}`;
+            const url = `${GITHUB_API_BASE}/repos/${owner}/${repoName}/commits/${sha}`;
             return await fetchWithCache(key, url);
         },
 
         /**
-         * getPRs(repo)
+         * getPRs(repo, owner)
          */
-        getPRs: async (repoName) => {
-            const key = `prs_${repoName}`;
-            const url = `${GITHUB_API_BASE}/repos/${ORG_NAME}/${repoName}/pulls?state=open&per_page=50`;
+        getPRs: async (repoName, owner = ORG_NAME) => {
+            const key = `prs_${owner}_${repoName}`;
+            const url = `${GITHUB_API_BASE}/repos/${owner}/${repoName}/pulls?state=open&per_page=50`;
             const prs = await fetchWithCache(key, url);
             return prs.map(pr => ({
                 number: pr.number,
@@ -204,11 +204,11 @@
         },
 
         /**
-         * getCommits(repo, branch, limit)
+         * getCommits(repo, branch, limit, owner)
          */
-        getCommits: async (repoName, branch = 'master', limit = 10) => {
-            const key = `commits_${repoName}_${branch}_${limit}`;
-            const url = `${GITHUB_API_BASE}/repos/${ORG_NAME}/${repoName}/commits?sha=${branch}&per_page=${limit}`;
+        getCommits: async (repoName, branch = 'master', limit = 10, owner = ORG_NAME) => {
+            const key = `commits_${owner}_${repoName}_${branch}_${limit}`;
+            const url = `${GITHUB_API_BASE}/repos/${owner}/${repoName}/commits?sha=${branch}&per_page=${limit}`;
             const commits = await fetchWithCache(key, url);
             return commits.map(c => ({
                 sha: c.sha,
@@ -222,13 +222,13 @@
         },
 
         /**
-         * getRepoContext(repo)
+         * getRepoContext(repo, owner)
          */
-        getRepoContext: async (repoName) => {
+        getRepoContext: async (repoName, owner = ORG_NAME) => {
             const [repos, prs, branches] = await Promise.all([
-                githubContext.getRepos(),
-                githubContext.getPRs(repoName),
-                githubContext.getBranches(repoName)
+                githubContext.getRepos(), // Still mostly org focused for now
+                githubContext.getPRs(repoName, owner),
+                githubContext.getBranches(repoName, owner)
             ]);
             const repo = repos.find(r => r.name === repoName);
             return {

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -1915,13 +1915,33 @@ permalink: /jules-panel/
 
             // Agrupar por owner
             const groups = {};
+            const currentUser = window.githubApi.user?.login;
+
             filteredSources.forEach(s => {
                 const owner = s.githubRepo?.owner || window.parseSourceName(s.name)?.owner || 'Otros';
                 if (!groups[owner]) groups[owner] = [];
                 groups[owner].push(s);
             });
 
-            Object.entries(groups).sort(([a], [b]) => a.localeCompare(b)).forEach(([owner, srcs]) => {
+            // Ordenar grupos: HYPENOSYS primero, luego otros alfabéticamente, luego el usuario actual al final
+            const sortedOwners = Object.keys(groups).sort((a, b) => {
+                const aUpper = a.toUpperCase();
+                const bUpper = b.toUpperCase();
+                const userUpper = currentUser?.toUpperCase();
+
+                if (aUpper === 'HYPENOSYS') return -1;
+                if (bUpper === 'HYPENOSYS') return 1;
+
+                if (userUpper) {
+                    if (aUpper === userUpper) return 1;
+                    if (bUpper === userUpper) return -1;
+                }
+
+                return aUpper.localeCompare(bUpper);
+            });
+
+            sortedOwners.forEach(owner => {
+                const srcs = groups[owner];
                 const groupHeader = document.createElement('div');
                 groupHeader.className = 'group-header-text text-[10px] font-bold text-slate-500 uppercase px-3 py-2 border-b border-slate-800 bg-slate-900/30';
                 groupHeader.textContent = owner;
@@ -1966,7 +1986,17 @@ permalink: /jules-panel/
                     repoSelect.value = s.name;
                     window.JulesPanelState.activeRepo = s.name;
                     localStorage.setItem('hypenosys_active_repo', s.name);
+                    localStorage.setItem('jules_selected_source', s.name);
+
+                    // Actualizar el label visual
+                    customLabel.textContent = displayLabel;
+
+                    // Trigger functional changes (branch loading, etc)
+                    await onRepoSelected(s.name, s);
+
+                    // Sync with other potential listeners
                     $(repoSelect).trigger('change');
+
                     customMenu.style.display = 'none';
                     updateRepoActiveTags(s.name);
                 };
@@ -2076,6 +2106,7 @@ permalink: /jules-panel/
       // Parse repo info
       const parsed = window.parseSourceName(sourceName);
       const repoName = parsed ? parsed.repo : sourceName;
+      const repoOwner = parsed ? parsed.owner : null;
 
       // Mostrar nombre real y habilitar lápiz
       realNameEl.textContent = sourceName;
@@ -2089,9 +2120,9 @@ permalink: /jules-panel/
       branchStatus.textContent = '';
 
       try {
-        const branches = await window.githubContext.getBranches(repoName);
-        const prs = await window.githubContext.getPRs(repoName);
-        const repoData = (await window.githubContext.getRepos()).find(r => r.name === repoName);
+        const branches = await window.githubContext.getBranches(repoName, repoOwner || undefined);
+        const prs = await window.githubContext.getPRs(repoName, repoOwner || undefined);
+        const repoData = (await window.githubContext.getRepos()).find(r => r.name === repoName && (repoOwner ? r.owner === repoOwner : true));
         const defaultBranch = repoData ? repoData.default_branch : 'main';
 
         // Poblar el <select> con metadatos


### PR DESCRIPTION
This PR fixes a bug in the Jules Panel where clicking a repository in the selector failed to update the active repository and load its branches.

Key changes:
1. **Repository Selector Fix**: Added a proper `onclick` handler to the custom dropdown items in `populateSelector`. This handler updates the UI label, persists the selection in `localStorage`, and triggers functional updates.
2. **Multi-Owner Support**: Enhanced `assets/javascript/github-context.js` to allow passing an `owner` parameter to API methods. This ensures that branches, PRs, and commits can be correctly fetched for repositories belonging to owners other than the default 'hypenosys' organization.
3. **Branch Loading Recovery**: Updated `onRepoSelected` to use the correct owner context, resolving the issue where branches failed to load for personal repositories (and potentially Task #34).
4. **Improved Sorting**: Refactored the repository grouping logic in the selector to prioritize 'HYPENOSYS' repositories and group the authenticated user's personal repositories at the bottom.
5. **Changelog Entry**: Added a detailed entry to `CHANGELOG.html` under the [Unreleased] section.

---
*PR created automatically by Jules for task [8773693403148231975](https://jules.google.com/task/8773693403148231975) started by @TopperH4rley*