### PR TITLE
Fix Robot Button Context in Claude Chat

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -195,6 +195,13 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Fixed</h5>
             <ul class="tree-view mb-3">
+              <li><strong>Robot Button Context in Claude Chat:</strong>
+                <ul>
+                  <li>Implementada la transferencia de contexto de tareas (ID, título, descripción, criterios) mediante <code>localStorage</code> al pulsar el botón robot en el Kanban.</li>
+                  <li>Actualizada la interfaz de Claude Chat para priorizar datos locales, autogenerar sesiones si es necesario y pre-rellenar el prompt con una instrucción directa.</li>
+                  <li>Corregido el fallo de carga de contexto que dependía de llamadas a la API de GitHub con ramas hardcodeadas.</li>
+                </ul>
+              </li>
               <li><strong>Jules Panel Selector & Branch Loading:</strong>
                 <ul>
                   <li>Corregido bug donde el selector de repositorio no actualizaba el repositorio activo al hacer clic.</li>

--- a/_data/dashboard_tasks.json
+++ b/_data/dashboard_tasks.json
@@ -1016,6 +1016,11 @@
           "id": 1780563057273,
           "text": "Vincular tarjeta ↔ sesión Jules por ID en jules-panel.html",
           "done": false
+        },
+        {
+          "id": 1780936990388,
+          "text": "BUG: Botón robot no pre-rellena contexto en Claude Chat (tags: frontend, ux, bug)",
+          "done": false
         }
       ],
       "acceptance_criteria": "El botón genere el prompt correcto y lo cargue en el panel.",

--- a/assets/javascript/dashboard-kanban.js
+++ b/assets/javascript/dashboard-kanban.js
@@ -102,7 +102,7 @@ function buildTaskCard(task) {
     <i class="fa-solid fa-pencil"></i>
   </button>`;
 
-  const robotBtn = `<button onclick="event.stopPropagation(); window.location.href='/claude-chat.html?task_id=${task.id}&from=dashboard'" class="action-btn text-indigo-400 hover:text-white" title="Enviar a Claude Chat (Neural Ops)">
+  const robotBtn = `<button onclick="event.stopPropagation(); window._openTaskInClaudeWithContext('${task.id}')" class="action-btn text-indigo-400 hover:text-white" title="Enviar a Claude Chat (Neural Ops)">
     <i class="fa-solid fa-robot"></i>
   </button>`;
 
@@ -412,3 +412,13 @@ async function handleMoveCard(taskId, direction) {
     const targetCol = KANBAN_COLUMNS[nextIndex];
     await handleCardDrop(taskId, targetCol.id);
 }
+
+window._openTaskInClaudeWithContext = function(taskId) {
+  if (typeof currentTasks !== 'undefined') {
+    const task = currentTasks.find(t => String(t.id) === String(taskId));
+    if (task) {
+      localStorage.setItem('claude_task_context', JSON.stringify(task));
+    }
+  }
+  window.location.href = `/claude-chat.html?task_id=${taskId}&from=dashboard`;
+};

--- a/assets/javascript/kanban-ui.js
+++ b/assets/javascript/kanban-ui.js
@@ -147,7 +147,12 @@
             const truncatedDesc = description.length > 80 ? description.substring(0, 77) + '...' : description;
 
             // Robot button action
-            const openInClaude = (taskId) => {
+            const openInClaude = async (taskId) => {
+                const tasks = await window.taskOps.getAllTasks();
+                const task = tasks.find(t => String(t.id) === String(taskId));
+                if (task) {
+                    localStorage.setItem('claude_task_context', JSON.stringify(task));
+                }
                 const url = `https://hypenosys.github.io/claude-chat.html?task_id=${taskId}&from=jules-panel`;
                 window.open(url, '_blank');
             };

--- a/pages/claude-chat.html
+++ b/pages/claude-chat.html
@@ -641,35 +641,59 @@ permalink: /claude-chat.html
             const urlParams = new URLSearchParams(window.location.search);
             const taskId = urlParams.get('task_id');
 
-            if (taskId) {
-                const task = await loadTaskContext(taskId);
-                if (task) {
-                    window._activeTaskContext = task;
-                    showTaskContextBanner(task);
-
-                    // If we have a task context and no session is active or it's a new one,
-                    // pre-fill the chat input with a structured request for Jules.
-                    if (!currentSessionId || sessions.find(s => s.id === currentSessionId)?.messages.length === 0) {
-                        const prompt = `Hola Claude. Ayúdame a preparar un prompt para Jules basado en esta tarea:
-Título: ${task.titulo || task.title}
-Descripción: ${task.descripcion || task.description}
-Criterios: ${task.acceptance_criteria || 'Ver descripción'}
-
-Analiza los requisitos y genera una instrucción técnica precisa que pueda enviar a Jules.`;
-                        chatInput.value = prompt;
-                        chatInput.style.height = 'auto';
-                        chatInput.style.height = (chatInput.scrollHeight) + 'px';
-                    }
-
-                    // Strip taskId from URL
-                    const newUrl = window.location.pathname + (window.location.search.includes('from=jules-panel') ? '?from=jules-panel' : '');
-                    window.history.replaceState({}, document.title, newUrl);
-                }
-            }
-
+            // 1. Initialize session UI first
             renderSessionList();
             if (sessions.length > 0) {
                 loadSession(sessions[0].id);
+            }
+
+            // 2. Load Task Context
+            let task = null;
+            const cachedTask = localStorage.getItem('claude_task_context');
+
+            if (cachedTask) {
+                try {
+                    const parsed = JSON.parse(cachedTask);
+                    if (taskId && String(parsed.id) === String(taskId)) {
+                        task = parsed;
+                    }
+                } catch (e) {
+                    console.error('[Claude] Error parsing cached task:', e);
+                }
+            }
+
+            if (taskId && !task) {
+                task = await loadTaskContext(taskId);
+            }
+
+            if (task) {
+                window._activeTaskContext = task;
+                showTaskContextBanner(task);
+
+                // Force a new session if coming from a task and the current one is not empty
+                const currentSession = sessions.find(s => s.id === currentSessionId);
+                if (currentSession && currentSession.messages.length > 0) {
+                    createNewSession();
+                } else if (!currentSessionId) {
+                    createNewSession();
+                }
+
+                // Pre-fill the chat input with context
+                const prompt = `Aquí tienes el contexto de la tarea. Ayúdame a implementarla o dame los próximos pasos.
+Título: ${task.titulo || task.title}
+Descripción: ${task.descripcion || task.description}
+Criterios: ${task.acceptance_criteria || 'Ver descripción'}`;
+
+                chatInput.value = prompt;
+                chatInput.style.height = 'auto';
+                chatInput.style.height = (chatInput.scrollHeight) + 'px';
+
+                // Strip taskId from URL
+                const newUrl = window.location.pathname + (window.location.search.includes('from=dashboard') || window.location.search.includes('from=jules-panel') ? `?from=${urlParams.get('from')}` : '');
+                window.history.replaceState({}, document.title, newUrl);
+
+                // Clear cache
+                localStorage.removeItem('claude_task_context');
             }
 
             // Load profiles and set active

--- a/pages/jules-paneltest2.html
+++ b/pages/jules-paneltest2.html
@@ -2066,6 +2066,9 @@ body{
     function openTaskInClaude(taskId) {
         const task = window.JulesPanelState.tasks.find(t => String(t.id) === String(taskId));
         if (!task) return;
+
+        localStorage.setItem('claude_task_context', JSON.stringify(task));
+
         if (task.images && task.images.length > 0) {
             showToast("Jules no acepta imágenes, se excluirán del prompt.", "amber");
         }


### PR DESCRIPTION
This PR fixes the issue where the robot button on Kanban cards did not pre-fill Claude Chat with the task context.

Key changes:
1. **Data Transfer**: Replaced API-dependent context loading in `claude-chat.html` with a robust `localStorage` (key: `claude_task_context`) hand-off.
2. **UI Updates**:
   - `dashboard-kanban.js`: Robot button now calls `_openTaskInClaudeWithContext`.
   - `kanban-ui.js`: Updated `openInClaude` to save context.
   - `jules-paneltest2.html`: Updated `openTaskInClaude` to save context.
3. **Claude Chat Logic**:
   - Prioritizes `localStorage` over URL parameters.
   - Pre-fills input with: "Aquí tienes el contexto de la tarea. Ayúdame a implementarla o dame los próximos pasos."
   - Automatically creates a new session if the current one contains messages.
   - Cleans up `task_id` from the URL and removes `localStorage` data after loading.
4. **Tracking**: Added subtask `1780936990388` to Task 27 in `_data/dashboard_tasks.json`.

---
*PR created automatically by Jules for task [14733017146401619571](https://jules.google.com/task/14733017146401619571) started by @Axlfc*