### PR TITLE
Fix Dashboard Branch Selector and Unify Repo Resolution

### DIFF
--- a/assets/javascript/dashboard-tasks.js
+++ b/assets/javascript/dashboard-tasks.js
@@ -599,31 +599,6 @@ function openImagePreview(taskId, idx, event) {
  * Fix 1 & 2: Dynamic branch selector and validation
  */
 
-function resolveRepoPath(value) {
-    if (!value) return null;
-
-    // Si ya es owner/repo
-    if (value.includes('/')) {
-        const [owner, repo] = value.split('/');
-        return { owner, repo };
-    }
-
-    // Si es un alias, buscar el repo real en el cache
-    const repos = window.userReposCache || [];
-    const repoObj = repos.find(r => {
-        const shortName = r.name;
-        const fullName = r.full_name;
-        const displayName = window.getRepoDisplayName ? window.getRepoDisplayName(fullName, shortName) : shortName;
-        return displayName === value || shortName === value;
-    });
-
-    if (repoObj) {
-        return { owner: repoObj.owner.login || repoObj.owner, repo: repoObj.name };
-    }
-
-    return null;
-}
-
 async function updateBranchList(repoValue) {
     const btn = document.getElementById('btn-list-branches');
     if (!btn) return;
@@ -650,7 +625,7 @@ async function showBranchDropdown() {
     const dropdown = document.getElementById('branch-dropdown');
     const repoValue = repoSelect ? repoSelect.value : null;
 
-    const path = resolveRepoPath(repoValue);
+    const path = window.parseSourceName(repoValue);
     if (!path) return;
 
     dropdown.innerHTML = '<div class="p-3 text-xs text-slate-500 italic">Cargando ramas...</div>';
@@ -720,7 +695,7 @@ function validateBranch() {
             return;
         }
 
-        const path = resolveRepoPath(repoValue);
+        const path = window.parseSourceName(repoValue);
         if (!path) {
             msg.classList.add('hidden');
             return;

--- a/assets/javascript/jules-api.js
+++ b/assets/javascript/jules-api.js
@@ -150,6 +150,14 @@ function parseSourceName(sourceName) {
   if (parts.length >= 4 && parts[1] === 'github') {
     return { owner: parts[2], repo: parts.slice(3).join('/') };
   }
+  // Formato 3 (Directo): owner/repo
+  if (parts.length === 2) {
+    return { owner: parts[0], repo: parts[1] };
+  }
+  // Formato 4 (Solo repo): repo (asumirá owner por defecto en el consumidor)
+  if (parts.length === 1 && sourceName.trim() !== '') {
+    return { owner: undefined, repo: sourceName.trim() };
+  }
   return null;
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -1043,6 +1043,8 @@ layout: null
       })();
     </script>
     <script src="{{ "/assets/javascript/github-api.js" | relative_url }}"></script>
+    <script src="{{ "/assets/javascript/github-context.js" | relative_url }}"></script>
+    <script src="{{ "/assets/javascript/jules-api.js" | relative_url }}"></script>
     <script src="{{ "/assets/javascript/ollama-discovery.js" | relative_url }}"></script>
     <script src="{{ "/assets/javascript/ai-config.js" | relative_url }}"></script>
     <script src="{{ "/assets/javascript/auth.js" | relative_url }}"></script>


### PR DESCRIPTION
This PR fixes the "No se pudieron cargar las ramas" error in the dashboard by synchronizing its logic with the functional implementation in Jules Panel.

### Changes:
1.  **Dependency Inclusion**: Added missing scripts `github-context.js` and `jules-api.js` to `dashboard.html`.
2.  **Logic Unification**: Replaced the local `resolveRepoPath` function in `dashboard-tasks.js` with the centralized `window.parseSourceName`.
3.  **Enhanced Parsing**: Updated `parseSourceName` in `jules-api.js` to handle:
    *   `sources/github-owner-repo` (New format)
    *   `sources/github/owner/repo` (Old format)
    *   `owner/repo` (Standard GitHub format)
    *   `repo` (Short format, defaults to org)

These changes resolve the `TypeError` where `githubContext` was undefined and ensure consistent repository identification across all modules.

---
*PR created automatically by Jules for task [5948535567873091274](https://jules.google.com/task/5948535567873091274) started by @Axlfc*