### PR TITLE
Fix Dashboard Auth and Null Pointer Exception

### DIFF
--- a/assets/javascript/auth.js
+++ b/assets/javascript/auth.js
@@ -259,10 +259,20 @@ class AuthManager {
     }
 
     updateHeaderUI(user) {
-        const container = document.getElementById('auth-nav-container');
-        const leftContainer = document.getElementById('auth-nav-container-left');
+        // Compatibility with new Dashboard header
+        if (typeof window.renderUserStatus === 'function' && (document.getElementById('user-status') || document.getElementById('user-status-mobile'))) {
+            window.renderUserStatus(user);
+            return;
+        }
+
+        const container = document.getElementById('auth-nav-container') || document.getElementById('user-status');
+        const leftContainer = document.getElementById('auth-nav-container-left') || document.getElementById('user-status-mobile');
         const chkHeader = document.getElementById('chk-remember-me');
-        if (chkHeader) chkHeader.parentElement.remove(); // Remove legacy checkbox UI
+
+        if (chkHeader && chkHeader.parentElement) {
+            chkHeader.parentElement.remove(); // Remove legacy checkbox UI
+        }
+
         if (!container) return;
 
         if (user && !user.login) {

--- a/assets/javascript/profile-editor.js
+++ b/assets/javascript/profile-editor.js
@@ -271,7 +271,7 @@
                 this.handleProviderChange(); // To show/hide base url
 
                 // Show modal AFTER populating
-                .modal('show');
+                $('#modalEditProfile').modal('show');
 
             } catch (err) {
                 console.error('[ProfileEditor] Error loading profile:', err);
@@ -413,7 +413,7 @@
                 }
 
                 window.hypeToast('Perfil actualizado correctamente ✓', 'success');
-                .modal('hide');
+                $('#modalEditProfile').modal('hide');
 
             } catch (err) {
                 console.error('[ProfileEditor] Save failed:', err);


### PR DESCRIPTION
This submission fixes the regression where the Dashboard showed "Acceso Restringido" even with a valid session and threw a "Cannot set properties of null (setting 'id')" error in the console.

The root cause was a mismatch between the DOM element IDs expected by auth.js (#auth-nav-container) and the actual IDs in the updated dashboard.html (#user-status). Additionally, profile-editor.js had syntax errors with missing jQuery selectors for modal operations.

Changes:
1.  **auth.js**: Modified `updateHeaderUI` to check for both old and new element IDs. It now also checks if `window.renderUserStatus` exists (defined in dashboard-ui.js) and delegates UI updates to it, ensuring consistent state across the modular dashboard architecture.
2.  **profile-editor.js**: Prepended `$('#modalEditProfile')` to `.modal('show')` and `.modal('hide')` calls to fix execution errors.
3.  **Defensive Coding**: Added null checks for parent elements before removal in auth.js.

These changes restore the authentication flow and fix the console errors, allowing users to access the dashboard and edit their profiles correctly.

---
*PR created automatically by Jules for task [4812836089448666701](https://jules.google.com/task/4812836089448666701) started by @Axlfc*