### PR TITLE
Fix Kanban rendering and Jules Panel V2 locking

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1051,6 +1051,8 @@ layout: null
     <script src="{{ "/assets/javascript/repo-aliases.js" | relative_url }}"></script>
 
     <!-- Dashboard Modules (UI & Logic) -->
+    <script src="{{ "/assets/javascript/task-engine.js" | relative_url }}"></script>
+    <script src="{{ "/assets/javascript/kanban-ui.js" | relative_url }}"></script>
     <script src="{{ "/assets/javascript/dashboard-config.js" | relative_url }}"></script>
     <script src="{{ "/assets/javascript/dashboard-kanban.js" | relative_url }}"></script>
     <script src="{{ "/assets/javascript/dashboard-charts.js" | relative_url }}"></script>

--- a/final_html.html
+++ b/final_html.html
@@ -1522,3 +1522,25 @@ body{
     </div>
   </div>
 </div>
+
+
+<script>
+    // Fix for Bug 2 in V2 Panel
+    document.addEventListener("authReady", (e) => {
+        console.log("[V2 PANEL] authReady received, unlocking UI");
+        document.getElementById("app-root")?.classList.remove("locked");
+        document.getElementById("auth-overlay")?.classList.remove("show");
+    });
+
+    // Manual bypass support
+    window.forceOpenPanel = function() {
+        document.getElementById("app-root")?.classList.remove("locked");
+        document.getElementById("auth-overlay")?.classList.remove("show");
+    };
+
+    // If already authenticated by the time this runs
+    if (localStorage.getItem('gh_access_token') || sessionStorage.getItem('gh_access_token')) {
+        document.getElementById("app-root")?.classList.remove("locked");
+        document.getElementById("auth-overlay")?.classList.remove("show");
+    }
+</script>

--- a/pages/jules-panel/index.html
+++ b/pages/jules-panel/index.html
@@ -1923,7 +1923,12 @@ body{
     }
 
     async function initRealPanel(user) {
-        if (!user && !getGitHubToken()) { showAuthCard("auth-card-login"); return; }
+        if (!user && !getGitHubToken()) {
+            showAuthCard("auth-card-login");
+            return;
+        }
+
+        // Fix for Bug 2: Unlock when we have a session or bypass
         $("auth-overlay").classList.remove("show");
         $("app-root").classList.remove("locked");
 


### PR DESCRIPTION
This PR fixes two regressions introduced in the last commit:
1. Kanban cards were appearing empty on the dashboard because task-engine.js and kanban-ui.js were not being loaded. I've added the required script tags in the correct order.
2. The Jules Panel V2 was remaining blurred (locked) even after authentication or bypass. I've updated the initialization logic to ensure the UI unlocks correctly.

---
*PR created automatically by Jules for task [8881781295789928052](https://jules.google.com/task/8881781295789928052) started by @Axlfc*