### PR TITLE
Fix Horizontal Overflow on Tablet Viewports in Claude Chat

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -108,6 +108,7 @@ permalink: /CHANGELOG.html
                 <ul>
                   <li>Corregida la visibilidad del menú lateral en móviles mediante el uso de colores de alto contraste (Dracula Theme) y la inclusión de navegación global.</li>
                   <li>Implementado el renderizado correcto de tablas Markdown con estilos temáticos, padding adecuado y scroll horizontal automático.</li>
+                  <li><strong>Responsividad en Tablets:</strong> Corregidos los desbordamientos horizontales en anchos de tablet (768px-1024px) asegurando que el texto largo se ajuste y los bloques de código permitan scroll horizontal en lugar de romper el diseño.</li>
                 </ul>
               </li>
               <li><strong>Sincronización de Selector de Ramas (Dashboard):</strong>

--- a/pages/claude-chat.html
+++ b/pages/claude-chat.html
@@ -181,6 +181,41 @@ permalink: /claude-chat.html
         }
     }
 
+    /* Tablet and Mobile Fixes for Horizontal Overflow */
+    @media (max-width: 1024px) {
+        #claude-main-interface,
+        main,
+        .chat-container,
+        #chat-messages {
+            max-width: 100%;
+            overflow-x: hidden !important;
+        }
+
+        .message-bubble,
+        .message-user,
+        .message-claude,
+        .prose {
+            max-width: 100%;
+            overflow-wrap: break-word;
+            word-wrap: break-word;
+            word-break: break-word;
+            overflow-x: hidden;
+        }
+
+        /* Code blocks inside messages */
+        #claude-main-interface pre,
+        #claude-main-interface code,
+        .prose pre,
+        .prose code,
+        .table-wrapper {
+            white-space: pre-wrap !important;
+            word-break: normal !important;
+            overflow-wrap: normal !important; /* Prioritize scrolling over breaking tokens */
+            overflow-x: auto !important;
+            max-width: 100% !important;
+        }
+    }
+
     .mobile-toggle {
         display: none;
         align-items: center;


### PR DESCRIPTION
The AI response text in the Claude Chat area was overflowing horizontally on tablet viewports (768px-1024px), breaking the layout and creating unwanted scrollbars.

This PR adds a specific media query for viewports up to 1024px that:
1.  Ensures all message containers and bubbles stay within the viewport (`max-width: 100%`, `overflow-x: hidden`).
2.  Forces long unbroken text strings to wrap (`overflow-wrap: break-word`).
3.  Optimizes code blocks to wrap long lines but allow horizontal scrolling for tokens that would otherwise break layout (`white-space: pre-wrap`, `overflow-x: auto`).

Verified visually at 1024px and 768px.

---
*PR created automatically by Jules for task [18403816635371658821](https://jules.google.com/task/18403816635371658821) started by @Axlfc*