### PR TITLE
Fix broken 'Enviar a Claude' button in dashboard.html

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1182,53 +1182,14 @@ layout: null
         renderSessions();
     })();
 
-    <!-- Hypenosys override: redirect to claude-chat.html -->
+    <!-- Hypenosys override: neural session entry point -->
     <script>
-    (function() {
-        window._openTaskInClaude = function(taskId) {
-            console.log('[HYPENOSYS] Intercepting Claude redirect for task:', taskId);
-
-            // Find task data from available global stores
-            const task = (window.taskOps?.getTaskSync ? window.taskOps.getTaskSync(taskId) : null)
-                         || (typeof currentTasks !== 'undefined' ? currentTasks.find(t => String(t.id) === String(taskId)) : null)
-                         || (window.JulesPanelState?.tasks?.find(t => String(t.id) === String(taskId)));
-
-            if (!task) {
-                console.error('[HYPENOSYS] Task not found for ID:', taskId);
-                if (window.showToast) window.showToast('Error: Tarea no encontrada', 'error');
-                return;
-            }
-
-            // Build enriched payload including history and comments
-            const payload = {
-                id: task.id,
-                titulo: task.titulo || task.title || '',
-                descripcion: task.descripcion || task.description || '',
-                rama: task.rama || task.branch || '',
-                estado: task.estado || task.status || '',
-                prioridad: task.prioridad || task.priority || '',
-                milestone: task.milestone || '',
-                tema_principal: task.tema_principal || '',
-                task_type: task.task_type || '',
-                asignados: task.asignados || task.asignado_a || [],
-                tags: task.tags || [],
-                comments: task.comments || task.comentarios || [],
-                subtasks: task.subtasks || task.subtareas || [],
-                history: task.history || task.changelog || [],
-                acceptance_criteria: task.acceptance_criteria || '',
-                repo: task.repo || task.repository || ''
-            };
-
-            const encodedData = encodeURIComponent(JSON.stringify(payload));
-            const url = `/claude-chat.html?task_data=${encodedData}`;
-
-            console.log('[HYPENOSYS] Redirecting to Claude with context:', payload);
-            console.log('[HYPENOSYS] Sample URL:', url);
-
-            window.open(url, '_blank');
-        };
-        console.log('[HYPENOSYS] Neural redirect override active');
-    })();
+    window._openTaskInClaude = function(taskId) {
+      const task = (window.currentTasks || []).find(t => String(t.id) === String(taskId)) || { id: taskId };
+      console.log('[HYPENOSYS] Neural entry:', taskId, task);
+      const payload = encodeURIComponent(JSON.stringify(task));
+      window.open('/claude-chat.html?task_data=' + payload, '_blank');
+    };
     </script>
 </body>
 </html>


### PR DESCRIPTION
This change fixes the 'Enviar a Claude' (robot) button in the dashboard Kanban board. The previous implementation was using a non-existent synchronous getter and had an unnecessary IIFE wrapper that made debugging difficult. 

The new implementation:
1. Uses `window.currentTasks` to find the task data.
2. Falls back to a minimal object if the task is not found.
3. Encodes the full task object as a URL parameter for `claude-chat.html`.
4. Is positioned at the absolute end of the `<body>` to ensure it correctly overrides any library-level defaults.

---
*PR created automatically by Jules for task [14695144109036227605](https://jules.google.com/task/14695144109036227605) started by @Axlfc*