### PR TITLE
Fix: Claude navigation flow cleanup and finalization

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -79,6 +79,7 @@ permalink: /CHANGELOG.html
               <li><strong>Interactividad de Tareas (Dashboard):</strong> Restaurada la funcionalidad de los botones robot (🤖) y "ENVIAR A CLAUDE" en el Kanban, integrándolos con el nuevo flujo de sesiones neurales.</li>
               <li><strong>Neural Session Responsiveness:</strong> Corregido el fallo donde los botones robot (🤖) y "ENVIAR A CLAUDE" no respondían en el dashboard. Se ajustó el orden de carga de scripts y se actualizó la detección de sesión en <code>neural-session.js</code> para usar <code>getAuthToken()</code>.</li>
               <li><strong>Neural Link Override:</strong> Asegurada la prioridad del override de <code>_openTaskInClaude</code> en el dashboard mediante un listener de <code>DOMContentLoaded</code> con retardo de 100ms, garantizando que gane a la inicialización por defecto de <code>kanban-ui.js</code>.</li>
+              <li><strong>Limpieza de Telemetría:</strong> Eliminados los logs de diagnóstico de <code>dashboard.html</code>, <code>kanban-ui.js</code> y <code>claude-chat.html</code> tras la validación exitosa del flujo de navegación "Enviar a Claude".</li>
             </ul>
             <h5 class="text-success">Added</h5>
             <ul>

--- a/assets/javascript/kanban-ui.js
+++ b/assets/javascript/kanban-ui.js
@@ -31,8 +31,6 @@
                     e.preventDefault();
                     e.stopPropagation();
 
-                    console.log(`[KANBAN] Action: ${action}, ID: ${id}, Event: ${e.type}`);
-
                     if (action === 'toggle') {
                         window.kanbanUI.toggleCard(id);
                     } else if (action === 'edit') {
@@ -240,9 +238,8 @@
                             } else {
                                 console.error('[KANBAN] NeuralSessionPanel not available');
                                 // Fallback to old behavior if everything fails
-                                 console.warn('[KANBAN] Retrying NeuralSession open failed, using fallback navigation');
                                 const url = `/claude-chat.html?task_id=${taskId}&from=jules-panel`;
-                                 window.location.href = url;
+                                window.location.href = url;
                             }
                         }, 800);
                     }

--- a/dashboard.html
+++ b/dashboard.html
@@ -1183,14 +1183,22 @@ layout: null
     })();
 
     <!-- Hypenosys override: neural session entry point -->
+    <script>window.SITE_BASEURL = '{{ "" | relative_url }}';</script>
     <script>
-    window._openTaskInClaude = function(taskId) {
-      const task = (window.currentTasks || []).find(t => String(t.id) === String(taskId)) || { id: taskId };
-      console.log('[HYPENOSYS] Neural entry:', taskId, task);
-      const payload = encodeURIComponent(JSON.stringify(task));
-      // Use window.location.href instead of window.open to comply with "no new tab" requirement
-      window.location.href = '/claude-chat.html?task_data=' + payload;
-    };
+    document.addEventListener('DOMContentLoaded', function() {
+      setTimeout(function() {
+        window._openTaskInClaude = function(taskId) {
+          try {
+            const task = (window.currentTasks || []).find(t => String(t.id) === String(taskId)) || { id: taskId };
+            const payload = encodeURIComponent(JSON.stringify(task));
+            const baseUrl = window.SITE_BASEURL || '';
+            window.location.href = baseUrl + '/claude-chat.html?task_data=' + payload;
+          } catch (e) {
+            console.error('_openTaskInClaude error:', e, e.stack);
+          }
+        };
+      }, 100);
+    });
     </script>
 </body>
 </html>

--- a/pages/claude-chat.html
+++ b/pages/claude-chat.html
@@ -1126,7 +1126,6 @@ permalink: /claude-chat.html
                     task = JSON.parse(decodeURIComponent(taskDataRaw));
                     localStorage.setItem('hy_neural_active', 'true');
                     localStorage.setItem('hy_neural_task_context', JSON.stringify(task));
-                    console.log('[NEURAL] Loaded task data from URL:', task);
                 } catch (e) {
                     console.error('[NEURAL] Error parsing task_data:', e);
                 }
@@ -2478,7 +2477,6 @@ permalink: /claude-chat.html
             // Preservation of window._activeTaskContext is implicit as it's a global variable
             // not touched by this function. We just ensure we don't clear it.
             session._compacting = true;
-            console.log(`[Neural Link] Compacting session ${session.id}...`);
 
             try {
                 const config = getActiveConfig();


### PR DESCRIPTION
This PR cleans up the diagnostic logs added during the troubleshooting of the "Enviar a Claude" / robot button navigation flow. It also ensures the final production state of the override in `dashboard.html` is robust and follows project patterns.

Key changes:
1.  **dashboard.html**: Removed `console.log` diagnostics. Refined the `window._openTaskInClaude` override to include `try/catch` error handling, use `window.SITE_BASEURL` for relative navigation, and remain wrapped in a `DOMContentLoaded` listener with a 100ms `setTimeout` to ensure priority over default handlers.
2.  **assets/javascript/kanban-ui.js**: Removed troubleshooting logs within `attachEvents`.
3.  **pages/claude-chat.html**: Removed minor diagnostic logs.
4.  **CHANGELOG.html**: Documented the cleanup in the [Unreleased] section.

All changes have been verified against the requested "final state" verbatim blocks and functional requirements.

---
*PR created automatically by Jules for task [8988354592499941559](https://jules.google.com/task/8988354592499941559) started by @Axlfc*