### PR TITLE
Fix _openTaskInClaude task passing and align chat persona

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -72,6 +72,8 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Fixed</h5>
             <ul>
+              <li><strong>Transferencia de Tareas a Claude:</strong> Corregido el bug en <code>_openTaskInClaude</code> donde solo se pasaba el ID de la tarea. Implementado un sistema de búsqueda multinivel (global y window scope) para asegurar que el objeto completo (título, descripción, etc.) llegue a <code>claude-chat.html</code>.</li>
+              <li><strong>Prompt y Persona de Claude Chat:</strong> Actualizada la construcción del prompt inicial para usar las claves correctas del esquema JSON (<code>title</code>, <code>descripcion</code>, <code>subtasks</code>) y adoptada la persona de "Asistente Técnico de Hypenosys", eliminando referencias a Senior Software Engineer.</li>
               <li><strong>Responsividad Táctil Kanban (Dashboard):</strong> Corregido el fallo donde los botones de las tarjetas (Robot 🤖, Editar ✎, Mover →) no respondían en dispositivos móviles. Se eliminaron los atributos <code>onclick</code> inline y se implementó un sistema de delegación de eventos unificado que soporta <code>click</code> y <code>touchend</code>.</li>
               <li><strong>Flujo de Tarea Claude Chat:</strong> Actualizada la transferencia de contexto de tarea para que ocurra en la misma pestaña (<code>window.location.href</code>) en lugar de abrir una nueva, evitando bloqueos de popups y manteniendo la continuidad de la sesión en móviles.</li>
               <li><strong>Sincronización Cross-Tab:</strong> Implementados listeners del evento <code>storage</code> para asegurar que los cambios de sesiones en el Jules Panel se reflejen instantáneamente en el Dashboard y viceversa.</li>

--- a/assets/javascript/kanban-ui.js
+++ b/assets/javascript/kanban-ui.js
@@ -40,8 +40,29 @@
                             openEditTaskModal(id);
                         }
                     } else if (action === 'claude') {
+                        let taskData = { id };
+
+                        // Primary: try window.currentTasks
+                        if (Array.isArray(window.currentTasks)) {
+                            const found = window.currentTasks.find(t => String(t.id) === String(id));
+                            if (found) taskData = found;
+                        }
+
+                        // Secondary: try window.kanbanData or window.allTasks as alternative global names
+                        if (taskData.id && !taskData.title) {
+                            const alt = (window.kanbanData || window.allTasks || []);
+                            const found = Array.isArray(alt) ? alt.find(t => String(t.id) === String(id)) : null;
+                            if (found) taskData = found;
+                        }
+
+                        // Tertiary: try the global currentTasks if available (common in dashboard-config.js)
+                        if (taskData.id && !taskData.title && typeof currentTasks !== 'undefined' && Array.isArray(currentTasks)) {
+                            const found = currentTasks.find(t => String(t.id) === String(id));
+                            if (found) taskData = found;
+                        }
+
                         if (typeof window._openTaskInClaude === 'function') {
-                            window._openTaskInClaude(id);
+                            window._openTaskInClaude(taskData);
                         }
                     } else if (action === 'move') {
                         const nextStatus = el.dataset.nextStatus;

--- a/dashboard.html
+++ b/dashboard.html
@@ -1187,10 +1187,26 @@ layout: null
     <script>
     document.addEventListener('DOMContentLoaded', function() {
       setTimeout(function() {
-        window._openTaskInClaude = function(taskId) {
+        window._openTaskInClaude = function(taskDataOrId) {
           try {
-            const task = (window.currentTasks || []).find(t => String(t.id) === String(taskId)) || { id: taskId };
-            const payload = encodeURIComponent(JSON.stringify(task));
+            let taskData = null;
+            let id = null;
+
+            if (typeof taskDataOrId === 'object' && taskDataOrId !== null) {
+              taskData = taskDataOrId;
+              id = taskData.id;
+            } else {
+              id = taskDataOrId;
+            }
+
+            // Robust fallback if we only have ID or missing key fields
+            if (!taskData || (!taskData.title && !taskData.titulo)) {
+              taskData = (window.currentTasks || []).find(t => String(t.id) === String(id))
+                      || (typeof currentTasks !== 'undefined' ? currentTasks.find(t => String(t.id) === String(id)) : null)
+                      || { id: id };
+            }
+
+            const payload = encodeURIComponent(JSON.stringify(taskData));
             const baseUrl = window.SITE_BASEURL || '';
             window.location.href = baseUrl + '/claude-chat.html?task_data=' + payload;
           } catch (e) {

--- a/pages/claude-chat.html
+++ b/pages/claude-chat.html
@@ -1173,23 +1173,30 @@ permalink: /claude-chat.html
                     let prompt = "";
                     if (taskDataRaw) {
                         // Format the pre-filled technical summary
-                        prompt = `Actúa como un Senior Software Engineer. He vinculado esta tarea al contexto neural:\n\n`;
-                        prompt += `📌 TAREA: #${task.id} - ${task.titulo}\n`;
+                        prompt = `He vinculado esta tarea para su análisis técnico:\n\n`;
+                        prompt += `📌 TAREA: #${task.id} - ${task.title || task.titulo || 'Sin título'}\n`;
                         prompt += `🔀 RAMA: ${task.rama || 'N/A'}\n`;
                         prompt += `📊 ESTADO: ${task.estado} | PRIORIDAD: ${task.prioridad}\n`;
                         if (task.descripcion) prompt += `📝 DESCRIPCIÓN: ${task.descripcion}\n`;
 
                         if (task.subtasks && task.subtasks.length > 0) {
-                            prompt += `📋 SUBTAREAS:\n` + task.subtasks.map(s => `  - [${s.done ? 'x' : ' '}] ${s.text || s.titulo}`).join('\n') + `\n`;
+                            prompt += `📋 SUBTAREAS:\n` + task.subtasks.map(s => {
+                                const text = typeof s === 'string' ? s : (s.text || s.titulo || '');
+                                const done = typeof s === 'object' && s.done;
+                                return `  - [${done ? 'x' : ' '}] ${text}`;
+                            }).join('\n') + `\n`;
                         }
 
                         if (task.comments && task.comments.length > 0) {
-                            prompt += `💬 COMENTARIOS RECIENTES:\n` + task.comments.map(c => `  - ${c.author || 'User'}: ${c.text || c.body}`).join('\n') + `\n`;
+                            prompt += `💬 COMENTARIOS RECIENTES:\n` + task.comments.map(c => {
+                                if (typeof c === 'string') return `  - ${c}`;
+                                return `  - ${c.author || c.author_login || 'User'}: ${c.text || c.body || ''}`;
+                            }).join('\n') + `\n`;
                         }
 
                         if (task.acceptance_criteria) prompt += `✅ CRITERIOS DE ACEPTACIÓN: ${task.acceptance_criteria}\n`;
 
-                        prompt += `\n¿Cómo podemos abordar esta implementación de forma eficiente?`;
+                        prompt += `\n¿Cómo podemos abordar esta tarea?`;
                     } else if (pendingPrompt) {
                         prompt = pendingPrompt;
                         localStorage.removeItem('hy_neural_pending_prompt');
@@ -1747,7 +1754,7 @@ permalink: /claude-chat.html
                 id,
                 title: 'Nueva Conversación',
                 messages: [],
-                systemPrompt: 'Eres Claude, un asistente experto para el estudio de videojuegos Hypenosys.',
+                systemPrompt: 'Eres un asistente técnico del estudio de videojuegos Hypenosys. Ayudas al equipo a planificar e implementar tareas de desarrollo. Responde siempre en español, de forma directa y técnica.',
                 createdAt: new Date().toISOString(),
                 task_ref: null
             };
@@ -1779,7 +1786,7 @@ permalink: /claude-chat.html
             if (window.godModeTools) {
                 const activeRepo = localStorage.getItem('hypenosys_active_repo');
                 const godContext = await window.godModeTools.getGodModeSystemPrompt(activeRepo);
-                if (!session.baseSystemPrompt) session.baseSystemPrompt = session.systemPrompt || 'Eres Claude, un asistente experto para el estudio de videojuegos Hypenosys.';
+                if (!session.baseSystemPrompt) session.baseSystemPrompt = session.systemPrompt || 'Eres un asistente técnico del estudio de videojuegos Hypenosys. Ayudas al equipo a planificar e implementar tareas de desarrollo. Responde siempre en español, de forma directa y técnica.';
                 session.systemPrompt = session.baseSystemPrompt + '\n' + godContext;
             }
 
@@ -2143,7 +2150,7 @@ permalink: /claude-chat.html
             const docKeywords = ['documentación', 'docs', 'readme', 'manual', 'cómo funciona', 'qué es', 'explica', 'describe'];
             const needsDocs = docKeywords.some(k => userMessage.toLowerCase().includes(k));
 
-            let systemPrompt = basePrompt || "Eres Claude Neural, el asistente de Hypenosys. Tienes acceso a la documentación del proyecto.";
+            let systemPrompt = basePrompt || "Eres un asistente técnico del estudio de videojuegos Hypenosys. Ayudas al equipo a planificar e implementar tareas de desarrollo. Responde siempre en español, de forma directa y técnica.";
 
             if (window._activeTaskContext) {
                 const t = window._activeTaskContext;


### PR DESCRIPTION
Fixed the bug where clicking the "Enviar a Claude" button only passed the task ID, resulting in "undefined" fields in the chat prompt. Implemented a robust lookup pattern across both the Kanban UI component and the dashboard-level override to ensure the full task object is retrieved from global state before navigation. Additionally, updated the chat interface to correctly use verified schema keys from the task data and adopted the requested technical assistant persona in the system prompts.

---
*PR created automatically by Jules for task [155085178020570487](https://jules.google.com/task/155085178020570487) started by @Axlfc*