### PR TITLE
Fix Claude communication in Jules Panel V2

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -88,6 +88,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Fixed</h5>
             <ul>
+              <li><strong>Comunicación con Claude (Jules Panel V2):</strong> Corregido el error "Error en comunicación con Claude" mediante la implementación de streaming (SSE) y el uso de headers de acceso directo (<code>anthropic-dangerous-direct-browser-access</code>), eliminando los bloqueos de CORS en producción y unificando la lógica con la versión funcional de Claude Chat.</li>
               <li><strong>Error 414 "URI Too Long" en Enlace a Jules:</strong> Corregido el fallo al enviar tareas con descripciones extensas mediante la migración del traspaso de datos desde parámetros de URL a un sistema de handoff basado en <code>localStorage</code> (clave <code>hy_jules_handoff</code>).</li>
               <li><strong>Duplicación de "Neural Session Activa":</strong> Corregido el bug donde se renderizaban dos tarjetas de sesión activa en el chat. Se centralizó el renderizado en <code>loadSession</code> y se eliminaron las llamadas redundantes en <code>init</code>.</li>
               <li><strong>Limpieza Global de Sesión (Desvincular):</strong> Actualizada la lógica de "Desvincular sesión" para limpiar globalmente todas las claves de <code>localStorage</code> que comienzan con <code>hy_neural_</code>, asegurando que no quede rastro de sesiones previas o de otras pestañas.</li>

--- a/pages/jules-paneltest2.html
+++ b/pages/jules-paneltest2.html
@@ -3336,7 +3336,7 @@ window.JulesPanelState = {
         renderChatV2Messages();
 
         try {
-            const config = window.aiConfig?.getActiveConfig() || JSON.parse(localStorage.getItem('hy_ai_config') || '{}');
+            const config = getActiveConfig();
             const prompt = `Jules ha completado una operación (Estado: ${output.status}).\n\nDETALLES:\n- Sesión: #${output.session_id}\n- Tarea: ${output.title}\n- Repo: ${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
 
             const messages = [
@@ -3412,6 +3412,15 @@ window.JulesPanelState = {
             }
         }
         return systemPrompt;
+    }
+
+    function getActiveConfig() {
+        const activeProfileId = localStorage.getItem('activeProfile');
+        const profiles = JSON.parse(localStorage.getItem('ai_profiles') || '{}');
+        if (activeProfileId && profiles[activeProfileId]) {
+            return profiles[activeProfileId];
+        }
+        return JSON.parse(localStorage.getItem('hy_ai_config') || '{}');
     }
 
     async function sendMessageAnthropic(sessionMessages, config) {
@@ -3553,8 +3562,13 @@ window.JulesPanelState = {
             }
 
             try {
-                const config = window.aiConfig?.getActiveConfig() || JSON.parse(localStorage.getItem('hy_ai_config') || '{}');
-                if (config.provider === 'anthropic' || (config.base_url && config.base_url.includes('anthropic.com'))) {
+                const config = getActiveConfig();
+                const provider = config.provider || 'none';
+                if (provider === 'none') {
+                    showToast('Configura un proveedor de IA en Credenciales API', 'red');
+                    return;
+                }
+                if (provider === 'anthropic') {
                     await sendMessageAnthropic(chatV2Messages, config);
                 } else {
                     const systemPrompt = await buildSystemPrompt(content, "Eres Claude, un asistente experto integrado en el panel de control de Hypenosys.");

--- a/pages/jules-paneltest2.html
+++ b/pages/jules-paneltest2.html
@@ -3379,6 +3379,118 @@ window.JulesPanelState = {
         }, 10000);
     }
 
+    async function buildSystemPrompt(userMessage, basePrompt) {
+        let systemPrompt = basePrompt || "Eres un asistente técnico del estudio de videojuegos Hypenosys. Ayudas al equipo a planificar e implementar tareas de desarrollo. Responde siempre en español, de forma directa y técnica.";
+
+        const t = window.JulesPanelState.activePayload?.source_task;
+        if (t) {
+            const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: ${t.blocks.join(', ')}` : 'No bloquea a nadie';
+            const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: ${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+
+            systemPrompt += `\n\n## Tarea activa en contexto\n` +
+                `ID: #${t.id}\n` +
+                `Título: ${t.titulo || t.title}\n` +
+                `Descripción: ${t.descripcion || t.description}\n` +
+                `Criterios de Aceptación: ${t.acceptance_criteria || 'N/A'}\n` +
+                `Subtareas: ${JSON.stringify(t.subtasks || [])}\n` +
+                `Estado: ${t.estado || t.status}\n` +
+                `Prioridad: ${t.prioridad || t.priority}\n` +
+                `Rama: ${t.rama || 'N/A'}\n` +
+                `Milestone: ${t.milestone || 'N/A'}\n` +
+                `Repositorio: ${t.repository || t.repo || 'N/A'}\n` +
+                `Dependencias: ${blockingInfo} | ${blockedByInfo}\n`;
+
+            const linkedSid = getLinkedJulesSessionId();
+            if (linkedSid) {
+                try {
+                    const activities = await window.julesApi.getActivities(linkedSid, 10);
+                    const logs = (activities.activities || []).map(a => a.description || a.progressUpdated?.title).filter(Boolean).join('\n');
+                    if (logs) {
+                        systemPrompt += `\n### Historial reciente de Jules (Sesión #${linkedSid}):\n${logs}\n`;
+                    }
+                } catch (e) { console.warn("Could not fetch Jules activity for context", e); }
+            }
+        }
+        return systemPrompt;
+    }
+
+    async function sendMessageAnthropic(sessionMessages, config) {
+        const apiKey = config.api_key || config.apiKey;
+        if (!apiKey) throw new Error('Anthropic API Key no configurada.');
+
+        const lastUserMessage = sessionMessages[sessionMessages.length - 1].content;
+        const dynamicSystemPrompt = await buildSystemPrompt(lastUserMessage, "Eres Claude, un asistente experto integrado en el panel de control de Hypenosys.");
+
+        const requestBody = {
+            model: config.model || 'claude-3-5-sonnet-20241022',
+            max_tokens: 4096,
+            messages: sessionMessages.map(m => ({ role: m.role, content: m.content })),
+            system: dynamicSystemPrompt,
+            stream: true
+        };
+
+        const response = await fetch('https://api.anthropic.com/v1/messages', {
+            method: 'POST',
+            headers: {
+                'x-api-key': apiKey,
+                'anthropic-version': '2023-06-01',
+                'content-type': 'application/json',
+                'anthropic-dangerous-direct-browser-access': 'true'
+            },
+            body: JSON.stringify(requestBody)
+        });
+
+        if (!response.ok) {
+            const errData = await response.json().catch(() => ({}));
+            throw new Error(errData.error?.message || `API Error: ${response.status}`);
+        }
+
+        await consumeStream(response);
+    }
+
+    async function consumeStream(response) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let aiContent = '';
+        let buffer = '';
+
+        const container = $('v2-chat-messages');
+        const msgDiv = document.createElement('div');
+        msgDiv.className = 'message-claude';
+        msgDiv.innerHTML = `
+            <div style="font-size: 10px; font-weight: 800; opacity: 0.5; margin-bottom: 8px; letter-spacing: 0.05em;">CLAUDE NEURAL</div>
+            <div class="prose-invert" id="streaming-content" style="font-size: 13.5px; line-height: 1.6;"></div>
+        `;
+        container.appendChild(msgDiv);
+        const streamEl = msgDiv.querySelector('#streaming-content');
+
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                const chunk = decoder.decode(value, { stream: true });
+                buffer += chunk;
+                const lines = buffer.split('\n');
+                buffer = lines.pop();
+                for (const line of lines) {
+                    const trimmedLine = line.trim();
+                    if (!trimmedLine || !trimmedLine.startsWith('data: ')) continue;
+                    try {
+                        const data = JSON.parse(trimmedLine.substring(6));
+                        if (data.type === 'content_block_delta' && data.delta.type === 'text_delta') {
+                            aiContent += data.delta.text;
+                            streamEl.innerHTML = marked.parse(aiContent);
+                            container.scrollTop = container.scrollHeight;
+                        }
+                    } catch (e) {}
+                }
+            }
+        } catch (e) { console.error('Stream error:', e); throw e; }
+
+        chatV2Messages.push({ role: 'assistant', content: aiContent });
+        renderChatV2Messages();
+    }
+
     async function sendChatV2Msg() {
         const input = $('v2-chat-input');
         const content = input.value.trim();
@@ -3395,7 +3507,6 @@ window.JulesPanelState = {
                 return;
             }
             const targetId = sessionId.startsWith('sessions/') ? sessionId : 'sessions/' + sessionId;
-            // Fix 3: Route Neural Chat messages to Jules session directly
             const userMsg = { role: 'user', content };
             chatV2Messages.push(userMsg);
             renderChatV2Messages();
@@ -3413,14 +3524,11 @@ window.JulesPanelState = {
                 if (ok) {
                     showToast("Orden enviada a Jules", "green");
                     addTel("USER", content, "info");
-
-                    // Poll for activity response
                     let attempts = 0;
-                    const maxAttempts = 15; // 30 seconds (2s interval)
+                    const maxAttempts = 15;
                     const pollInterval = setInterval(async () => {
                         attempts++;
                         await refreshActivities(getIdSafe(sessionId));
-
                         if (attempts >= maxAttempts) {
                             clearInterval(pollInterval);
                             if (thinking) thinking.classList.add('hidden');
@@ -3432,7 +3540,6 @@ window.JulesPanelState = {
                 if (thinking) thinking.classList.add('hidden');
             }
         } else {
-            // Add user message
             const userMsg = { role: 'user', content };
             chatV2Messages.push(userMsg);
             renderChatV2Messages();
@@ -3447,25 +3554,18 @@ window.JulesPanelState = {
 
             try {
                 const config = window.aiConfig?.getActiveConfig() || JSON.parse(localStorage.getItem('hy_ai_config') || '{}');
-                const systemPrompt = "Eres Claude, un asistente experto integrado en el panel de control de Hypenosys.";
-
-                // Build context from active task if exists
-                let fullPrompt = content;
-                if (window.JulesPanelState.activePayload?.source_task) {
-                    const t = window.JulesPanelState.activePayload.source_task;
-                    fullPrompt = `[CONTEXTO TAREA #${t.id}: ${t.titulo}]\n${content}`;
+                if (config.provider === 'anthropic' || (config.base_url && config.base_url.includes('anthropic.com'))) {
+                    await sendMessageAnthropic(chatV2Messages, config);
+                } else {
+                    const systemPrompt = await buildSystemPrompt(content, "Eres Claude, un asistente experto integrado en el panel de control de Hypenosys.");
+                    const messages = [
+                        { role: 'system', content: systemPrompt },
+                        ...chatV2Messages.map(m => ({ role: m.role, content: m.content }))
+                    ];
+                    const response = await callCustomProvider(config, messages);
+                    chatV2Messages.push({ role: 'assistant', content: response });
+                    renderChatV2Messages();
                 }
-
-                const messages = [
-                    { role: 'system', content: systemPrompt },
-                    ...chatV2Messages.map(m => ({ role: m.role, content: m.content }))
-                ];
-
-                // For now, use a simplified non-streaming call for the integrated tab
-                const response = await callCustomProvider(config, messages);
-
-                chatV2Messages.push({ role: 'assistant', content: response });
-                renderChatV2Messages();
             } catch (e) {
                 console.error('[ChatV2] Error:', e);
                 showToast("Error en comunicación con Claude", "red");


### PR DESCRIPTION
This PR fixes the "Error en comunicación con Claude" in Jules Panel V2 by:
1. Migrating from non-streaming `callCustomProvider` to streaming `sendMessageAnthropic`.
2. Adding the `anthropic-dangerous-direct-browser-access: true` header to bypass CORS in production.
3. Injecting rich context (Task metadata + recent Jules activities) via `buildSystemPrompt`.
4. Ensuring consistency with the working `/chat/neural/` implementation.

---
*PR created automatically by Jules for task [14153899448851215009](https://jules.google.com/task/14153899448851215009) started by @TopperH4rley*