### PR TITLE
Fix "Nueva sesión" button and SVG console errors in Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -74,6 +74,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Added</h5>
             <ul>
+              <li><strong>Funcionalidad de Nueva Sesión:</strong> El botón "Nueva sesión" en el Jules Panel ahora inicia correctamente una conversación limpia en el Neural Chat, archivando la sesión anterior y regenerando el identificador de contexto.</li>
               <li><strong>Unificación de Configuración IA:</strong> El Panel V2 ahora utiliza el mismo modal de configuración que el chat principal, garantizando paridad de funcionalidades y sincronización automática de credenciales entre <code>hy_ai_config</code> y <code>jules_api_key</code>.</li>
               <li><strong>Validación Estricta de Ollama:</strong> Implementada validación en tiempo de envío para prevenir errores 404. El sistema ahora detecta si falta la Base URL o el Modelo y guía al usuario para completar la configuración.</li>
               <li><strong>Soporte Nativo Ollama en Panel V2:</strong> Añadida compatibilidad con el endpoint nativo <code>/api/chat</code> y el formato NDJSON para sesiones locales de Ollama desde el panel de control.</li>
@@ -100,6 +101,8 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Fixed</h5>
             <ul>
+               <li><strong>Iconografía SVG en Panel V2:</strong> Corregidos errores de sintaxis en las rutas de los iconos de Configuración y Ramas (paths malformados) que generaban alertas en la consola del navegador.</li>
+               <li><strong>Acción del Botón "Nueva Sesión":</strong> Reemplazada la llamada a una función inexistente (<code>scrollToSession</code>) por la implementación real de inicio de sesión neural.</li>
                <li><strong>Botón de Envío Neural Chat:</strong> Corregido el fallo que bloqueaba el envío de mensajes debido a una función de persistencia no definida (`saveSessionsV2`). Implementada la unificación de sesiones con el chat principal y garantizado el desbloqueo de la interfaz tras cualquier operación.</li>
                <li><strong>Conexión Flawless Neural Chat (Panel V2):</strong> Corregido el motor de enrutamiento de mensajes para respetar el modo seleccionado (Claude/Jules) y asegurar la recuperación de API Keys en todos los contextos de la versión V2.</li>
                <li><strong>Persistencia de Configuración V2:</strong> Habilitados los botones de guardado en los modales de API y Repositorio del Panel V2, garantizando la sincronización inmediata con <code>localStorage</code> y <code>hy_ai_config</code>.</li>

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -1272,7 +1272,7 @@ body{
     <span>Neural</span>
   </button>
   <button class="mtab" data-tab="config">
-    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
     <span>Config</span>
   </button>
 </nav>
@@ -1377,7 +1377,7 @@ body{
         <button class="btn btn-ghost btn-sm" onclick="openApiModal()">
           <span class="u-dot" style="margin-right:3px"></span>API Key
         </button>
-        <button class="btn btn-primary btn-sm" id="hdr-new-btn" onclick="scrollToSession()">
+        <button class="btn btn-primary btn-sm" id="hdr-new-btn" onclick="startNewNeuralSession()">
           <svg width="12" height="12" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
           Nueva sesión
         </button>
@@ -1496,7 +1496,7 @@ body{
               Crear Tests
             </div>
             <div class="opt-pill" id="opt-branch">
-              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 7v8a2 2 0 002 2h6M8 7a2 2 114 0 2 2 0 01-4 0zm8 8a2 2 114 0 2 2 0 01-4 0z"/></svg>
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 7v8a2 2 0 002 2h6M8 7a2 2 0 114 0 2 2 0 01-4 0zm8 8a2 2 0 114 0 2 2 0 01-4 0z"/></svg>
               Rama Dedicada
             </div>
           </div>
@@ -2685,6 +2685,19 @@ window.JulesPanelState = {
 
         const encodedData = encodeURIComponent(JSON.stringify(fullTask));
         window.location.href = `/chat/neural/?task_data=${encodedData}`;
+    }
+
+    function startNewNeuralSession() {
+        desvincularNeuralSession();
+
+        const newClaudeId = 'session_' + (window.crypto?.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15));
+        localStorage.setItem('hy_active_claude_session_id', newClaudeId);
+
+        chatV2Messages = [];
+
+        switchView('chat');
+
+        showToast("Nueva sesión de chat iniciada", "green");
     }
 
     function desvincularNeuralSession() {


### PR DESCRIPTION
The "Nueva sesión" button in the Jules Panel header was calling an undefined function `scrollToSession()`, resulting in no action. This PR implements the missing logic via `startNewNeuralSession()`, which ensures a fresh chat state is initialized and the UI switches to the Neural Chat view.

Additionally, several SVG icons in the Jules Panel had malformed path strings (missing spaces in arc and bezier commands), which caused "Expected arc flag" errors in the browser console. These have been corrected to ensure a clean console and proper rendering.

Changes:
- Added `startNewNeuralSession()` to `pages/jules-panel.html`.
- Updated `#hdr-new-btn` `onclick` handler.
- Fixed malformed SVG `d` attributes in `pages/jules-panel.html`.
- Logged changes in `CHANGELOG.html`.

---
*PR created automatically by Jules for task [16398790358870696851](https://jules.google.com/task/16398790358870696851) started by @TopperH4rley*