### PR TITLE
Fix duplicate 'archive' declaration in jules-panel.html

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -74,6 +74,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul>
+              <li><strong>SyntaxError en Jules Panel (V2):</strong> Corregido el error <code>SyntaxError: Identifier 'archive' has already been declared</code> que impedía la carga del Kanban de tareas. Se renombró la variable local duplicada a <code>localArchive</code> y se actualizaron todas sus referencias en la función <code>loadJulesKanban</code>.</li>
               <li><strong>Estabilidad del Jules Panel (v2):</strong> Implementado manejo de errores no bloqueante en la carga de datos globales. El fallo en la recuperación del archivo de estado o de la API de GitHub ya no detiene la inicialización del panel, garantizando que los menús y métricas básicas sigan siendo accesibles.</li>
               <li><strong>Sincronización de Archivo Global:</strong> Corregidos problemas de inconsistencia y parpadeo mediante la implementación de un flag <code>isSyncingArchive</code> que bloquea actualizaciones de UI durante la escritura atómica en GitHub.</li>
             </ul>

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -2758,7 +2758,7 @@ window.JulesPanelState = {
                 }, "chore: limpieza automática de archivo global (estados terminales o cambiados)");
             }
 
-            const archive = JSON.parse(localStorage.getItem('jules_internal_archive') || '{}');
+            const localArchive = JSON.parse(localStorage.getItem('jules_internal_archive') || '{}');
 
             // 1. Terminal State Cleanup: If real state is already terminal, clear archive entry
             ['done', 'error'].forEach(colId => {
@@ -2767,7 +2767,7 @@ window.JulesPanelState = {
                     const taskIdMatch = (s.title || s.prompt || '').match(/#(\d+)/);
                     const taskId = taskIdMatch ? taskIdMatch[1] : null;
                     const archiveId = taskId || sid;
-                    if (archive[archiveId]) delete archive[archiveId];
+                    if (localArchive[archiveId]) delete localArchive[archiveId];
                 });
             });
 
@@ -2779,11 +2779,11 @@ window.JulesPanelState = {
                     const taskId = taskIdMatch ? taskIdMatch[1] : null;
                     const archiveId = taskId || sid;
 
-                    const entry = archive[archiveId];
+                    const entry = localArchive[archiveId];
                     if (entry) {
                         // Conflict check: if real status changed (e.g. Pending -> Working), invalidate local archive
                         if (s.state !== entry.realState) {
-                            delete archive[archiveId];
+                            delete localArchive[archiveId];
                             return true;
                         }
                         // Move to internal target
@@ -2793,7 +2793,7 @@ window.JulesPanelState = {
                     return true;
                 });
             });
-            localStorage.setItem('jules_internal_archive', JSON.stringify(archive));
+            localStorage.setItem('jules_internal_archive', JSON.stringify(localArchive));
 
             Object.keys(colItems).forEach(colId => {
                 const colEl = $(`kb-${colId}`), countEl = $(`kb-count-${colId}`), mCountEl = $(`m-count-${colId}`);
@@ -2814,7 +2814,7 @@ window.JulesPanelState = {
                     const taskId = taskIdMatch ? taskIdMatch[1] : null;
                     const archiveId = taskId || sid;
 
-                    const isArchived = archive[archiveId] !== undefined;
+                    const isArchived = localArchive[archiveId] !== undefined;
                     const repo = s.sourceContext?.source?.split('/').pop() || '---';
                     const canDrag = (colId === 'pending' || colId === 'running') && !isArchived;
 


### PR DESCRIPTION
The Jules Panel was failing to load due to a JavaScript SyntaxError where the 'archive' variable was declared twice in the same scope of the 'loadJulesKanban' function. 

This change renames the second declaration (which reads from localStorage) to 'localArchive' and ensures all subsequent logic in that block uses the updated identifier. The first 'archive' variable (which reads from global state) remains unchanged to preserve existing functionality.

---
*PR created automatically by Jules for task [16869629999940098398](https://jules.google.com/task/16869629999940098398) started by @TopperH4rley*