### PR TITLE
Add SECCIÓN field to Kanban dashboard tasks

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,8 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-white">Added</h5>
             <ul>
+                <li><strong>Campo SECCIÓN en Kanban Dashboard:</strong> Implementado un nuevo campo de metadatos "SECCIÓN" en las tareas del dashboard, permitiendo categorizar cambios que afectan a áreas específicas como Jules Panel, Chat Neural o el propio Dashboard.</li>
+                <li><strong>Filtrado por SECCIÓN:</strong> Añadida una nueva fila de filtros dinámicos en el dashboard que permite filtrar por sección, soportando valores separados por comas (lógica OR) para una gestión multi-área.</li>
                 <li><strong>Renderizado Dinámico del Equipo:</strong> La sección "The Dream Team" en la landing page ahora se genera dinámicamente mediante JavaScript, permitiendo el uso de archivos JSON fuera de la carpeta <code>_data</code> de Jekyll.</li>
                 <li><strong>Global Card Archiving (Jules Panel):</strong> Upgraded the internal organization system to be global for all users. Archived states are now persisted in <code>_data/jules_panel_state.json</code> via GitHub commits, ensuring team-wide synchronization of the Kanban board view.</li>
                 <li><strong>Internal Card Archiving (Jules Panel):</strong> Users can now drag session cards from EN COLA/EN PROGRESO to COMPLETADO or BLOQUEADO columns for internal organization. Archived cards are visually dimmed and display an "Archived" badge.</li>

--- a/assets/javascript/dashboard-config.js
+++ b/assets/javascript/dashboard-config.js
@@ -61,7 +61,8 @@ let kanbanFilters = {
     states: [],
     milestones: [],
     themes: [],
-    priorities: []
+    priorities: [],
+    sections: []
 };
 let currentTasks = [];
 let archivedTasks = [];
@@ -185,6 +186,14 @@ function getFilteredTasks(tasks) {
   // 7. Priorities (OR)
   if (kanbanFilters.priorities && kanbanFilters.priorities.length > 0) {
     filtered = filtered.filter(t => kanbanFilters.priorities.includes(t.prioridad || 'Sin Prioridad'));
+  }
+
+  // 8. Sections (OR)
+  if (kanbanFilters.sections && kanbanFilters.sections.length > 0) {
+    filtered = filtered.filter(t => {
+      const taskSections = (t.seccion || 'Sin Sección').split(',').map(s => s.trim()).filter(s => s);
+      return kanbanFilters.sections.some(s => taskSections.includes(s));
+    });
   }
 
   return filtered;

--- a/assets/javascript/dashboard-tasks.js
+++ b/assets/javascript/dashboard-tasks.js
@@ -51,6 +51,7 @@ function openCreateTaskModal() {
   document.getElementById('task-priority-input').value = 'Major';
   document.getElementById('task-milestone-input').value = 'M1';
   document.getElementById('task-topic-input').value = 'Programación / Engine';
+  document.getElementById('task-section-input').value = '';
   document.getElementById('task-repo-input').value = defaultRepo;
   document.getElementById('task-status-input').value = 'Pending';
   document.getElementById('task-completion-input').value = '0';
@@ -107,6 +108,7 @@ function openEditTaskModal(taskId) {
     document.getElementById('task-priority-input').value = task.prioridad || 'Major';
     document.getElementById('task-milestone-input').value = task.milestone || 'M1';
     document.getElementById('task-topic-input').value = task.tema_principal || 'Programación / Engine';
+    document.getElementById('task-section-input').value = task.seccion || '';
     document.getElementById('task-repo-input').value = task.repository || '';
     let status = task.estado || 'Pending';
     if (status === '?') status = 'In Review';
@@ -168,6 +170,7 @@ async function handleCreateTask() {
   const priority = document.getElementById('task-priority-input').value;
   const milestone = document.getElementById('task-milestone-input').value;
   const topic = document.getElementById('task-topic-input').value;
+  const seccion = document.getElementById('task-section-input').value.trim();
   const repository = document.getElementById('task-repo-input').value || null;
   const status = document.getElementById('task-status-input').value;
   const completion = parseFloat(document.getElementById('task-completion-input').value) || 0;
@@ -193,6 +196,7 @@ async function handleCreateTask() {
     rama,
     task_type: taskType,
     tema_principal: topic,
+    seccion: seccion,
     repository: repository,
     prioridad: priority,
     milestone,
@@ -516,7 +520,7 @@ function closeLightbox() {
 
 
 function diffTasks(oldTask, newTask) {
-    const fields = ['title', 'descripcion', 'estado', 'prioridad', 'milestone', 'asignados', 'blocks', 'blocked_by', 'due_date', 'task_type', 'tags', 'completitud', 'repository'];
+    const fields = ['title', 'descripcion', 'estado', 'prioridad', 'milestone', 'asignados', 'blocks', 'blocked_by', 'due_date', 'task_type', 'tags', 'completitud', 'repository', 'seccion'];
     const changes = [];
     const timestamp = new Date().toISOString();
     const author = window.currentUser || 'Unknown';

--- a/assets/javascript/dashboard-ui.js
+++ b/assets/javascript/dashboard-ui.js
@@ -586,7 +586,7 @@ function toggleKanbanFilters() {
 
     const isCollapsed = container.style.maxHeight === '0px' || container.style.maxHeight === '' || container.classList.contains('max-h-0');
     const totalActive = kanbanFilters.tags.length + kanbanFilters.members.length + kanbanFilters.repos.length + kanbanFilters.states.length +
-                        kanbanFilters.milestones.length + kanbanFilters.themes.length + kanbanFilters.priorities.length;
+                        kanbanFilters.milestones.length + kanbanFilters.themes.length + kanbanFilters.priorities.length + kanbanFilters.sections.length;
 
     if (isCollapsed) {
         container.classList.remove('max-h-0', 'opacity-0');
@@ -726,6 +726,7 @@ function renderKanbanFilters() {
     const allMilestones = new Set();
     const allThemes = new Set();
     const allPriorities = new Set();
+    const allSections = new Set();
 
     currentTasks.forEach(t => {
         if (t.tags) t.tags.forEach(tag => allTags.add(tag));
@@ -734,6 +735,9 @@ function renderKanbanFilters() {
         allMilestones.add(t.milestone || 'Sin Milestone');
         allThemes.add(t.tema_principal || 'Sin Tema');
         allPriorities.add(t.prioridad || 'Sin Prioridad');
+
+        const sections = (t.seccion || 'Sin Sección').split(',').map(s => s.trim()).filter(s => s);
+        sections.forEach(s => allSections.add(s));
     });
 
     const sortedTags = Array.from(allTags).sort();
@@ -741,6 +745,7 @@ function renderKanbanFilters() {
     const sortedMilestones = Array.from(allMilestones).sort();
     const sortedThemes = Array.from(allThemes).sort();
     const sortedPriorities = Array.from(allPriorities).sort();
+    const sortedSections = Array.from(allSections).sort();
     const allStates = ['PENDING', 'WORKING', 'IN REVIEW', 'OK', 'CRITICAL', 'TODO'];
 
     container.innerHTML = '';
@@ -852,7 +857,20 @@ function renderKanbanFilters() {
     });
     container.appendChild(prioritiesRow.row);
 
-    // Fila 7: Estados y Botón Limpiar
+    // Fila 7: Secciones
+    const sectionsRow = createRow('Sección', 'fa-solid fa-puzzle-piece');
+    sortedSections.forEach(section => {
+        const active = kanbanFilters.sections.includes(section);
+        const pill = createPill(section, active, () => {
+            if (active) kanbanFilters.sections = kanbanFilters.sections.filter(s => s !== section);
+            else kanbanFilters.sections.push(section);
+            renderDashboard();
+        });
+        sectionsRow.content.appendChild(pill);
+    });
+    container.appendChild(sectionsRow.row);
+
+    // Fila 8: Estados y Botón Limpiar
     const lastRowWrapper = document.createElement('div');
     lastRowWrapper.className = 'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 pt-2 border-t border-slate-800/50';
 
@@ -873,7 +891,7 @@ function renderKanbanFilters() {
     clearBtn.className = 'text-[10px] font-black text-slate-500 hover:text-red-400 uppercase tracking-widest transition-all flex items-center gap-2 px-3 py-2 bg-slate-950 rounded-lg border border-slate-800 hover:border-red-900/50';
     clearBtn.innerHTML = '<i class="fa-solid fa-trash-can"></i> Limpiar todo';
     clearBtn.onclick = () => {
-        kanbanFilters = { tags: [], members: [], repos: [], states: [], milestones: [], themes: [], priorities: [] };
+        kanbanFilters = { tags: [], members: [], repos: [], states: [], milestones: [], themes: [], priorities: [], sections: [] };
         renderDashboard();
     };
     lastRowWrapper.appendChild(clearBtn);

--- a/assets/javascript/kanban-ui.js
+++ b/assets/javascript/kanban-ui.js
@@ -343,6 +343,9 @@
                         <!-- Description (Always visible as requested) -->
                         ${description ? `<div class="task-description">${parsedDesc}</div>` : ''}
 
+                        <!-- Sección -->
+                        ${task.seccion ? `<div class="text-[9px] text-indigo-400/80 font-bold uppercase truncate mt-2">${task.seccion}</div>` : ''}
+
                         <!-- Line 3: Repo + Branch -->
                         <div class="flex justify-between items-center text-[10px] text-slate-500 mt-2 pt-2 border-t border-slate-800/50">
                             <span class="truncate max-w-[60%] text-slate-400"><i class="fas fa-folder opacity-50 mr-1"></i>${displayRepo}</span>
@@ -383,6 +386,7 @@
                             <span><span class="text-slate-600 mr-1">STAGE:</span> ${task.tema_principal || '---'}</span>
                             <span><span class="text-slate-600 mr-1">MIL.:</span> ${task.milestone || '---'}</span>
                             <span><span class="text-slate-600 mr-1">TYPE:</span> ${task.task_type || '---'}</span>
+                            <span><span class="text-slate-600 mr-1">SECCIÓN:</span> ${task.seccion || '---'}</span>
                         </div>
 
                         <!-- Fila: Repo + Branch -->

--- a/dashboard.html
+++ b/dashboard.html
@@ -598,6 +598,10 @@ layout: null
                                 <option value="Post-launch">Post-launch</option>
                             </select>
                         </div>
+                        <div>
+                            <label class="block text-xs font-bold text-slate-500 uppercase mb-2">Sección</label>
+                            <input type="text" id="task-section-input" class="w-full bg-slate-950 border border-slate-800 rounded-lg p-2 text-slate-100 focus:border-emerald-500 outline-none" placeholder="Ej: Jules Panel, Chat Neural...">
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
This change adds a new 'SECCIÓN' (Section) field to the Kanban dashboard tasks, allowing users to categorize tasks (e.g., 'Jules Panel', 'Chat Neural') and filter by these categories.

Key changes:
1. **UI**: Added a 'Sección' input to the task modal and displayed the value on Kanban cards.
2. **Logic**: Updated task creation/update flows to handle the new field.
3. **Filtering**: Added a new filter row in the dashboard to filter tasks by section. Supports comma-separated sections (e.g., 'Jules, Chat') by splitting them into individual filter pills and matching logic.
4. **Tracking**: Included the field in the change log system.

---
*PR created automatically by Jules for task [511773103915412663](https://jules.google.com/task/511773103915412663) started by @Axlfc*