### PR TITLE
Restore Archive Button on COMPLETADO Cards

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-white">Added</h5>
             <ul>
+                <li><strong>Kanban Card Archiving (COMPLETADO):</strong> Restaurado el botón de archivar (<code>fa-box-archive</code>) en las tarjetas de la columna COMPLETADO (estados OK/Closed) para permitir mover tareas al Cementerio directamente desde el Kanban.</li>
                 <li><strong>Jules Activity Feed:</strong> Implementada una nueva pestaña de Actividad en el Neural Chat que muestra logs de ejecución, planes y comandos de Jules en tiempo real con estética Dracula.</li>
                 <li><strong>Renderizado Dinámico del Equipo:</strong> La sección "The Dream Team" en la landing page ahora se genera dinámicamente mediante JavaScript, permitiendo el uso de archivos JSON fuera de la carpeta <code>_data</code> de Jekyll.</li>
                 <li><strong>Global Card Archiving (Jules Panel):</strong> Upgraded the internal organization system to be global for all users. Archived states are now persisted in <code>_data/jules_panel_state.json</code> via GitHub commits, ensuring team-wide synchronization of the Kanban board view.</li>

--- a/assets/javascript/kanban-ui.js
+++ b/assets/javascript/kanban-ui.js
@@ -39,6 +39,12 @@
                         } else if (typeof openEditTaskModal === 'function') {
                             openEditTaskModal(id);
                         }
+                    } else if (action === 'archive') {
+                        if (typeof window.handleArchiveTask === 'function') {
+                            window.handleArchiveTask(id);
+                        } else if (typeof handleArchiveTask === 'function') {
+                            handleArchiveTask(id);
+                        }
                     } else if (action === 'claude') {
                         let taskData = { id };
 
@@ -226,6 +232,7 @@
 
             const priorityColor = priorityColors[task.prioridad] || 'bg-slate-500';
             const statusColor = statusBadgeColors[task.estado] || statusBadgeColors[task.status] || 'badge-todo';
+            const isDone = ['OK', 'Closed', 'DONE'].includes(task.estado) || ['OK', 'Closed', 'DONE'].includes(task.status);
 
             const statusBorderClasses = {
                 'Pending': 'border-status-pending',
@@ -323,12 +330,17 @@
                             <div class="flex items-center gap-2">
                                 <span class="font-mono text-slate-500 font-bold">#${task.id}</span>
                                 <div class="flex gap-1.5">
-                                    <button data-action="edit" data-id="${task.id}" class="text-slate-500 hover:text-white transition-colors" title="Editar">
+                                    <button data-action="edit" data-id="${task.id}" class="w-[28px] h-[28px] flex items-center justify-center text-slate-500 hover:text-white transition-colors" title="Editar">
                                         <i class="fas fa-pencil-alt"></i>
                                     </button>
-                                    <button data-action="claude" data-id="${task.id}" class="text-slate-500 hover:text-[#bd93f9] transition-colors" title="Robot">
+                                    <button data-action="claude" data-id="${task.id}" class="w-[28px] h-[28px] flex items-center justify-center text-slate-500 hover:text-[#bd93f9] transition-colors" title="Robot">
                                         <i class="fas fa-robot"></i>
                                     </button>
+                                    ${isDone ? `
+                                    <button data-action="archive" data-id="${task.id}" class="w-[28px] h-[28px] flex items-center justify-center text-slate-500 hover:text-emerald-400 transition-colors" title="Archivar">
+                                        <i class="fa-solid fa-box-archive"></i>
+                                    </button>
+                                    ` : ''}
                                 </div>
                                 <span class="badge ${statusColor}">${displayStatus}</span>
                             </div>
@@ -366,8 +378,11 @@
                             <div class="flex items-center gap-2">
                                 <span class="text-[10px] font-bold text-slate-500 font-mono">#${task.id}</span>
                                 <div class="flex gap-1.5 mr-1">
-                                    <button data-action="edit" data-id="${task.id}" class="text-slate-500 hover:text-white" title="Editar"><i class="fas fa-pencil-alt"></i></button>
-                                    <button data-action="claude" data-id="${task.id}" class="text-slate-500 hover:text-[#bd93f9]" title="Robot"><i class="fas fa-robot"></i></button>
+                                    <button data-action="edit" data-id="${task.id}" class="w-[28px] h-[28px] flex items-center justify-center text-slate-500 hover:text-white" title="Editar"><i class="fas fa-pencil-alt"></i></button>
+                                    <button data-action="claude" data-id="${task.id}" class="w-[28px] h-[28px] flex items-center justify-center text-slate-500 hover:text-[#bd93f9]" title="Robot"><i class="fas fa-robot"></i></button>
+                                    ${isDone ? `
+                                    <button data-action="archive" data-id="${task.id}" class="w-[28px] h-[28px] flex items-center justify-center text-slate-500 hover:text-emerald-400" title="Archivar"><i class="fa-solid fa-box-archive"></i></button>
+                                    ` : ''}
                                 </div>
                                 <span class="badge ${statusColor}">${displayStatus}</span>
                                 <span class="badge ${priorityColor} text-[8px] px-1.5 py-0.5 rounded uppercase font-bold">${task.prioridad}</span>


### PR DESCRIPTION
Restores the missing archive button on Kanban cards that are in a completed state (OK or Closed). The button is placed in the card header next to the edit and robot actions, maintaining visual consistency and providing a 28x28px touch area for mobile users. Archiving a task correctly triggers the existing confirmation flow and moves the task to the studio's cemetery (archived JSON).

---
*PR created automatically by Jules for task [14465043387414701158](https://jules.google.com/task/14465043387414701158) started by @Axlfc*