### PR TITLE
Fix Jules-Neural Sync & Automation

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -87,6 +87,9 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul>
+              <li><strong>Automatización de "Analizar con Claude":</strong> El flujo de análisis ahora es completamente automático, fusionando fragmentos y preguntas en un solo bloque y disparando la respuesta de Claude instantáneamente sin intervención manual.</li>
+              <li><strong>Sincronización Bidireccional Neural Final:</strong> Corregida la latencia y omisión de mensajes de usuario en la sincronización. Los mensajes enviados desde el standalone aparecen ahora instantáneamente en el panel de control gracias al formato de payload <code>NEW_MESSAGE</code> estandarizado.</li>
+              <li><strong>Persistencia de la Pestaña ACTIVIDAD:</strong> El feed de actividad de Jules en el standalone ahora se guarda localmente, permitiendo que el historial, planes y logs de terminal sigan siendo visibles tras refrescar la página o cambiar de sesión sin depender del polling.</li>
               <li><strong>Extracción de Texto en "Analizar con Claude":</strong> Corregido el bug que enviaba placeholders <code>[FRAGMENTO 1]</code> en lugar del contenido real. Ahora el botón extrae correctamente mensajes de usuario, respuestas de Jules, pasos del plan, diffs de código y salidas de terminal.</li>
               <li><strong>Flujo "Enviar a Jules" (Neural Link):</strong> Refactorizado el receptor de handoff para diferenciar entre "Modo Iniciador" (nueva tarea en vista Neural) y "Modo Aditivo" (envío directo de mensaje a sesión activa). Resuelto el bug que enviaba el texto al campo de chat equivocado.</li>
               <li><strong>Sincronización de Acciones de Mensaje:</strong> Unificado el flujo de envío de fragmentos de Claude para usar el sistema de payload enriquecido, garantizando que el contexto de la tarea se mantenga.</li>

--- a/pages/claude-chat.html
+++ b/pages/claude-chat.html
@@ -1201,10 +1201,20 @@ permalink: /chat/neural/
                 activityTab.classList.remove('border-transparent', 'text-[#6272a4]');
                 chatTab.classList.remove('border-[#bd93f9]', 'text-[#bd93f9]');
                 chatTab.classList.add('border-transparent', 'text-[#6272a4]');
+
+                // [FIX 2C] Restaurar actividades desde localStorage al activar pestaña
+                const linkedSid = localStorage.getItem('hy_neural_session_id_' + currentSessionId) || localStorage.getItem('hy_neural_session_id');
+                if (linkedSid) {
+                    const idSafe = linkedSid.split('/').pop();
+                    const saved = localStorage.getItem(`hy_activity_feed_${idSafe}`);
+                    if (saved && window._updateActivityFeed) {
+                        window._updateActivityFeed(JSON.parse(saved), true); // true para evitar re-guardado
+                    }
+                }
             }
         };
 
-        window._updateActivityFeed = (activities) => {
+        window._updateActivityFeed = (activities, skipSave = false) => {
             const container = document.getElementById('activity-log-container');
             const emptyState = document.getElementById('activity-empty-state');
 
@@ -1212,6 +1222,15 @@ permalink: /chat/neural/
                 emptyState.classList.remove('hidden');
                 container.innerHTML = '';
                 return;
+            }
+
+            // [FIX 2C] Persistir actividades bajo clave de sesión Jules
+            if (!skipSave) {
+                const linkedSid = localStorage.getItem('hy_neural_session_id_' + currentSessionId) || localStorage.getItem('hy_neural_session_id');
+                if (linkedSid) {
+                    const idSafe = linkedSid.split('/').pop();
+                    localStorage.setItem(`hy_activity_feed_${idSafe}`, JSON.stringify(activities));
+                }
             }
 
             emptyState.classList.add('hidden');
@@ -2197,9 +2216,17 @@ permalink: /chat/neural/
             if (neuralId) {
                 localStorage.setItem('hy_neural_session_id', neuralId);
                 startJulesPolling(neuralId);
+
+                // [FIX 2C] Intentar precargar feed de actividad guardado
+                const idSafe = neuralId.split('/').pop();
+                const saved = localStorage.getItem(`hy_activity_feed_${idSafe}`);
+                if (saved && window._updateActivityFeed) {
+                    window._updateActivityFeed(JSON.parse(saved), true);
+                }
             } else {
                 localStorage.removeItem('hy_neural_session_id');
                 stopJulesPolling();
+                if (window._updateActivityFeed) window._updateActivityFeed([]);
             }
 
             // Close sidebar on mobile after selecting a session
@@ -2271,9 +2298,13 @@ permalink: /chat/neural/
                         const lastMsg = currentSession.messages[currentSession.messages.length - 1];
                         window.neuralSyncChannel.postMessage({
                             type: 'NEW_MESSAGE',
-                            julesSessionId: linkedSid || null,
+                            julesSessionId: linkedSid || localStorage.getItem('hy_active_jules_session'),
                             claudeConversationId: currentSessionId,
-                            message: lastMsg
+                            message: {
+                                role: lastMsg.role,
+                                content: lastMsg.content,
+                                timestamp: lastMsg.timestamp || Date.now()
+                            }
                         });
                     }
                 }
@@ -2802,11 +2833,11 @@ permalink: /chat/neural/
                     return;
                 }
 
-                const userMsg = { role: 'user', content: content };
+                const userMsg = { role: 'user', content: content, timestamp: Date.now() };
                 if (currentSession) {
                     currentSession.messages.push(userMsg);
+                    saveSessions(); // [FIX 2B] Emitir inmediatamente
                     renderMessages();
-                    saveSessions();
                 }
 
                 sendBtn.disabled = true;
@@ -2857,6 +2888,7 @@ permalink: /chat/neural/
             const userMsg = {
                 role: 'user',
                 content: content,
+                timestamp: Date.now(),
                 image: attachedImage || undefined
             };
             if (currentSession) currentSession.messages.push(userMsg);
@@ -2874,9 +2906,10 @@ permalink: /chat/neural/
             // Set title from first message (Tarea 2.5 - 40 chars)
             if (currentSession && currentSession.title === 'Nueva Conversación' && content) {
                 currentSession.title = content.substring(0, 40) + (content.length > 40 ? '...' : '');
-                saveSessions();
-                renderSessionList();
             }
+
+            // [FIX 2B] Emitir mensaje del usuario inmediatamente via saveSessions
+            saveSessions();
 
             chatInput.value = '';
             chatInput.style.height = 'auto';

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -3847,7 +3847,11 @@ window.JulesPanelState = {
                         type: 'NEW_MESSAGE',
                         julesSessionId: sessionId,
                         claudeConversationId: claudeId,
-                        message: lastMsg
+                        message: {
+                            role: lastMsg.role,
+                            content: lastMsg.content,
+                            timestamp: lastMsg.timestamp || Date.now()
+                        }
                     });
                 }
             }
@@ -4899,8 +4903,7 @@ window.JulesPanelState = {
             .map(el => _historySelection.get(el.dataset.activityId))
             .filter(Boolean);
 
-        let prompt = "He seleccionado estos fragmentos del historial de Jules para analizar:\n\n";
-        let contextForClaude = "";
+        let combinedMessage = "He seleccionado estos fragmentos del historial de Jules para analizar:\n\n";
 
         sortedEntries.forEach((act, idx) => {
             let activityType = "Actividad";
@@ -4942,32 +4945,28 @@ window.JulesPanelState = {
             }
 
             if (content) {
-                contextForClaude += separator + content;
+                combinedMessage += separator + content;
             }
         });
 
-        showToast("Selección cargada en el chat neural", "green");
+        combinedMessage += "\n\n¿Qué opinas de estos cambios o estados de Jules seleccionados arriba? ¿Hay algo que deba ajustar o corregir?";
 
-        // Add "JULES" messages to history for visualization
-        chatV2Messages.push({
-            role: 'jules',
-            content: contextForClaude
-        });
-        saveSessionsV2(); // Emit the context
-
-        // Append the actual question to Claude
-        chatV2Messages.push({
-            role: 'user',
-            content: prompt + "\n¿Qué opinas de estos cambios o estados de Jules seleccionados arriba? ¿Hay algo que deba ajustar o corregir?"
-        });
-
-        saveSessionsV2(); // Emit the actual user question
-        renderChatV2Messages();
+        // Cambiar a vista chat y pre-poblar input
         switchView('chat');
-        clearHistorySelection();
+        const input = $('v2-chat-input');
+        if (input) {
+            input.value = combinedMessage;
+            input.style.height = 'auto';
+            input.dispatchEvent(new Event('input'));
+        }
 
-        // Trigger automatic response from Claude if a session is active
-        setTimeout(() => sendChatV2Msg(), 500);
+        clearHistorySelection();
+        showToast("Iniciando análisis con Claude...", "green");
+
+        // Disparar envío automático
+        setTimeout(() => {
+            sendChatV2Msg();
+        }, 300);
     }
 
     function commentOnStep(sessionId, stepIndex, stepTitle) {


### PR DESCRIPTION
Final fixes for the neural integration between Jules Panel and Claude Chat.

1. **Automatic Analysis**: "Analizar con Claude" in Jules Panel now merges all context into one block and triggers Claude immediately.
2. **Bidirectional Sync**: User messages from the standalone chat are now visible in the Jules Panel in real-time, thanks to immediate BroadcastChannel emissions and standardized payload formats.
3. **Activity Persistence**: The 'ACTIVIDAD' tab in Claude Chat now persists across refreshes and session changes by saving the feed to localStorage, removing the reliance on active polling for historical data.

---
*PR created automatically by Jules for task [14623381605964088000](https://jules.google.com/task/14623381605964088000) started by @Axlfc*