### PR TITLE
Instrumentación de Diagnóstico: Jules Control Hub

### DIFF
--- a/assets/javascript/jules-api.js
+++ b/assets/javascript/jules-api.js
@@ -46,7 +46,10 @@ async function julesApiCall(method, endpoint, body = null, customKey = null) {
             throw new Error('RATE_LIMIT');
         }
         if (!res.ok) {
-            throw new Error(data?.error?.message || `HTTP ${res.status}`);
+            const error = new Error(data?.error?.message || `HTTP ${res.status}`);
+            error.fullDetails = data?.error || data;
+            error.httpStatus = res.status;
+            throw error;
         }
 
         return data;

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -3539,7 +3539,16 @@ window.JulesPanelState = {
             }
 
             $('session-prompt').value = ''; await refreshDashboard();
-        } catch (e) { showToast(e.message || "Error al lanzar sesión", "red"); }
+        } catch (e) {
+            console.error("[Jules Debug] Error en createSession:", e);
+            const errorInfo = {
+                message: e.message,
+                status: e.httpStatus,
+                details: e.fullDetails
+            };
+            addTel("SYSTEM", JSON.stringify(errorInfo), "error");
+            showToast(e.message || "Error al lanzar sesión", "red");
+        }
         finally {
             btn.disabled = false;
             textarea.disabled = false;


### PR DESCRIPTION
Esta PR añade instrumentación de logging para diagnosticar el error 'FAILED_PRECONDITION' al iniciar una sesión de Jules. 
- En `jules-api.js`, el objeto Error ahora incluye `fullDetails` (JSON de respuesta) y `httpStatus`.
- En `jules-panel.html`, el bloque `catch` de `launchSession` vuelca estos datos en el panel de Monitoreo Neural bajo la etiqueta SYSTEM.
- No hay cambios en la lógica de negocio ni en funciones restringidas.
- Confirmado: No existen workflows de PR preview en el repositorio, por lo que se recomienda fusionar a master para probar en el entorno de GitHub Pages.

---
*PR created automatically by Jules for task [12246753430518786059](https://jules.google.com/task/12246753430518786059) started by @Axlfc*