### PR TITLE
Fix broken pages after refactor: Unescape template literals and clean Jekyll includes

### DIFF
--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -1,6 +1,3 @@
-<script src="{{ '/assets/javascript/bootstrap/jquery.min.js' | relative_url }}"></script>
-<script src="{{ '/assets/javascript/bootstrap/bootstrap.bundle.min.js' | relative_url }}"></script>
-<script src="{{ '/assets/javascript/ui-components.js' | relative_url }}"></script>
 <style>
 /* ─── VARIABLES ─── */
 :root {

--- a/_includes/repo-admin-styles.html
+++ b/_includes/repo-admin-styles.html
@@ -1,4 +1,4 @@
-}
+<style>
 .ra-chip-svn { border-color: rgba(249,124,106,0.3); }
 .ra-chip-git { border-color: rgba(106,247,200,0.3); }
 .ra-chip-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--c-text3); transition: all 0.3s; }
@@ -343,45 +343,9 @@
   .ra-drawer { width: 100%; }
   .ra-action-btn, .ra-connect-btn { padding: 10px 16px; font-size: 12px; }
 }
-</style>
 
 <script>
 /* ════════════════════════════════════════
    N8N WORKFLOWS — copy from Settings
    ════════════════════════════════════════ */
-const WORKFLOWS = {
-  'svn-list': {
-    name: "SVN List",
-    nodes: [
-      {
-        parameters: {
-          httpMethod: ["POST"], path: "svn-list",
-          responseMode: "responseNode",
-          options: { allowedOrigins: "https://hypenosys.github.io" }
-        },
-        type: "n8n-nodes-base.webhook", typeVersion: 2.1,
-        position: [400, -200], id: "wh-svn-list", name: "Webhook SVN List"
-      },
-      {
-        parameters: {
-          language: "python",
-          code: `import subprocess, json
-body = items[0]['json']['body']
-path = body.get('path', '')
-svn_url = f"svn://100.64.74.27/hypenosys/trunk/Hypenosys/{path}".rstrip('/')
-user = body.get('user', 'SVN_USERNAME')
-pwd = body.get('password', 'SVN_PASSWORD')
-result = subprocess.run(
-  ['svn', 'list', '--xml', '--username', user, '--password', pwd, '--no-auth-cache', '--non-interactive', svn_url],
-  capture_output=True, text=True, timeout=30
-)
-if result.returncode != 0:
-  return [{'json': {'error': result.stderr, 'path': path}}]
-import xml.etree.ElementTree as ET
-root = ET.fromstring(result.stdout)
-entries = []
-for entry in root.findall('.//entry'):
-  name = entry.find('name').text or ''
-  kind = entry.get('kind', 'file')
-  commit = entry.find('commit')
-  rev = commit.get('revision') if commit is not None else ''
+</style>

--- a/assets/javascript/jules-panel-auth.js
+++ b/assets/javascript/jules-panel-auth.js
@@ -27,7 +27,7 @@ window.initRealPanel = async function(user) {
 
     if (user) {
         updateUserUI(user);
-        addTel("SYSTEM", `Iniciado como \${user.login}`, "success");
+        addTel("SYSTEM", `Iniciado como ${user.login}`, "success");
     } else {
         addTel("SYSTEM", `Iniciado como Invitado`, "success");
     }
@@ -78,19 +78,19 @@ window.prefillTaskFromHandoff = async function(task) {
     if (payloadStr) {
         try {
             payload = JSON.parse(payloadStr);
-            if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+            if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
             if (payload.session_context && typeof payload.session_context === 'string') {
-                formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+                formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
             }
             if (payload.claude_response) {
-                formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+                formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
             }
         } catch(e) { console.error("Error parsing payload", e); }
     }
 
     if (!formattedPrompt) {
-        formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #\${task.id} - \${task.titulo || task.title}\n`;
-        if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: \${task.descripcion}\n`;
+        formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #${task.id} - ${task.titulo || task.title}\n`;
+        if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: ${task.descripcion}\n`;
         formattedPrompt += `\n¿Cómo podemos abordar esta tarea?`;
     }
 
@@ -99,12 +99,12 @@ window.prefillTaskFromHandoff = async function(task) {
 
     if (targetRepo) {
         const source = (window.julesSourcesCache || []).find(src =>
-            src.name === targetRepo || src.name === `sources/github/\${targetRepo}` || src.displayName === targetRepo
+            src.name === targetRepo || src.name === `sources/github/${targetRepo}` || src.displayName === targetRepo
         );
         if (source) {
             switchRepo(source.name, source);
         } else if (targetRepo.includes('/')) {
-            const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/\${targetRepo}`;
+            const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/${targetRepo}`;
             switchRepo(sourceName, { name: sourceName });
         }
     }
@@ -123,9 +123,9 @@ window.prefillTaskFromHandoff = async function(task) {
                             const sessCtx = $('sess-ctx');
                             if(sessCtx) {
                                 const repoLabel = $('repo-label').textContent;
-                                sessCtx.textContent = `\${repoLabel}: \${targetBranch}`;
+                                sessCtx.textContent = `${repoLabel}: ${targetBranch}`;
                             }
-                            addTel("SYSTEM", `Rama auto-ajustada a \${targetBranch} (Tarea #\${task.id})`, "info");
+                            addTel("SYSTEM", `Rama auto-ajustada a ${targetBranch} (Tarea #${task.id})`, "info");
                             resolve(true);
                         } else {
                             resolve(false);
@@ -143,7 +143,7 @@ window.prefillTaskFromHandoff = async function(task) {
 
         const exists = await waitForBranches();
         if (!exists) {
-             formattedPrompt = `Crea la branch \${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+             formattedPrompt = `Crea la branch ${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
              addTel("SYSTEM", `Instrucción de creación de branch añadida al prompt`, "warn");
         }
     }
@@ -183,7 +183,7 @@ window.prefillTaskFromHandoff = async function(task) {
 
         if ($('neural-session-banner')) {
             $('neural-session-banner').classList.remove('hidden');
-            $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+            $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
         }
         showTaskContextInChat(task);
 
@@ -250,7 +250,7 @@ window.checkClipboard = function() {
         const task = JSON.parse(localStorage.getItem('hy_neural_task_context') || '{}');
         if (task.id) {
             $('neural-session-banner').classList.remove('hidden');
-            $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+            $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
             showTaskContextInChat(task);
         }
     }
@@ -270,15 +270,15 @@ window.checkClipboard = function() {
             let formattedPrompt = "";
 
             if (payload.user_note) {
-                formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+                formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
             }
 
             if (payload.session_context && typeof payload.session_context === 'string') {
-                formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+                formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
             }
 
             if (payload.claude_response) {
-                formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+                formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
             }
 
             promptArea.value = formattedPrompt.trim();
@@ -334,10 +334,10 @@ window.checkClipboard = function() {
 }
 
 window.updateUserUI = async function(user) {
-    const avatarUrl = user.avatar_url || `https://github.com/\${user.login}.png`;
+    const avatarUrl = user.avatar_url || `https://github.com/${user.login}.png`;
 
     if ($('sb-avatar')) {
-        $('sb-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+        $('sb-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
     }
     if ($('sb-user-name')) {
         $('sb-user-name').textContent = user.login;
@@ -345,12 +345,12 @@ window.updateUserUI = async function(user) {
 
     if ($('mob-avatar')) {
         $('mob-avatar').style.display = 'flex';
-        $('mob-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+        $('mob-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
     }
 
     if ($('hdr-user')) {
         $('hdr-user').style.display = 'flex';
-        $('hdr-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+        $('hdr-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
         $('hdr-username').textContent = user.login;
     }
 
@@ -380,7 +380,7 @@ window.desvincularNeuralSession = function() {
     localStorage.removeItem('hy_neural_active');
     const claudeId = localStorage.getItem('hy_active_claude_session_id');
     if (claudeId) {
-        localStorage.removeItem(`hy_neural_session_id_\${claudeId}`);
+        localStorage.removeItem(`hy_neural_session_id_${claudeId}`);
     }
     localStorage.removeItem('hy_neural_session_id');
     localStorage.removeItem('hy_neural_task_context');
@@ -400,7 +400,7 @@ window.launchSession = async function() {
     if (!prompt) { $('session-prompt').focus(); showToast("Escribe una tarea para Jules", "red"); return; }
     const source = window.JulesPanelState.activeRepo, branch = window.JulesPanelState.activeBranch || 'master';
 
-    addTel("SYSTEM", `Iniciando sesión - Source: "\${source}", Branch: "\${branch}"`, "info");
+    addTel("SYSTEM", `Iniciando sesión - Source: "${source}", Branch: "${branch}"`, "info");
     console.log("[Jules Debug] Source:", source, "Branch:", branch);
 
     if (!source || source.includes("Cargando")) {
@@ -417,7 +417,7 @@ window.launchSession = async function() {
         prompt += "\n\nIMPORTANTE: Genera tests unitarios automáticos para cubrir estos cambios.";
     }
     if ($('opt-branch').classList.contains('active')) {
-        prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-\${Date.now()}).`;
+        prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-${Date.now()}).`;
     }
 
     const btn = $('launch-btn');
@@ -440,17 +440,17 @@ window.launchSession = async function() {
         const res = await window.julesApi.createSession(body);
         const sid = res.name.split('/').pop();
         showToast("Sesión iniciada correctamente", "green");
-        addTel("JULES", `Sesión iniciada: \${sid}`, "success");
+        addTel("JULES", `Sesión iniciada: ${sid}`, "success");
 
         const claudeId = localStorage.getItem('hy_active_claude_session_id');
         if (claudeId) {
-            localStorage.setItem(`hy_neural_session_id_\${claudeId}`, sid);
+            localStorage.setItem(`hy_neural_session_id_${claudeId}`, sid);
         }
         localStorage.setItem('hy_neural_session_id', sid);
 
         startNeuralPolling(sid, true);
         const taskContext = JSON.parse(localStorage.getItem('hy_neural_task_context') || '{}');
-        const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural \${new Date().toLocaleDateString()}`;
+        const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural ${new Date().toLocaleDateString()}`;
         const now = new Date().toISOString();
 
         localStorage.setItem('hy_neural_active', 'true');

--- a/assets/javascript/jules-panel-hub.js
+++ b/assets/javascript/jules-panel-hub.js
@@ -8,7 +8,7 @@ window.switchHubTab = async function(tabId, el) {
     if(el) el.classList.add('active');
     document.querySelectorAll('.hub-panel').forEach(p => p.style.display = 'none');
     const tabMap = { 'pull-requests': 'pr', 'issues': 'issues', 'branches': 'branches', 'actions': 'actions', 'notifications': 'notifs' };
-    const panel = $(`panel-\${tabMap[tabId]}`);
+    const panel = $(`panel-${tabMap[tabId]}`);
     if(panel) panel.style.display = 'block';
     await loadHubContent(tabId);
 }
@@ -17,7 +17,7 @@ window.loadHubContent = async function(tabId, force = false) {
     const repoVal = window.JulesPanelState.activeRepo; if (!repoVal) return;
     const parsed = window.parseSourceName(repoVal); if (!parsed) return;
     const tabMap = { 'pull-requests': 'pr', 'issues': 'issues', 'branches': 'branches', 'actions': 'actions', 'notifications': 'notifs' };
-    const panel = $(`panel-\${tabMap[tabId]}`);
+    const panel = $(`panel-${tabMap[tabId]}`);
     const now = Date.now(), lastFetch = parseInt(panel.dataset.fetchedAt || '0', 10);
     if (!force && panel.dataset.loaded === 'true' && (now - lastFetch < 60000)) return;
     panel.innerHTML = '<div style="padding:40px; text-align:center; color:var(--text3);">Cargando...</div>';
@@ -28,46 +28,46 @@ window.loadHubContent = async function(tabId, force = false) {
         else if (tabId === 'actions') await fetchHubActions(parsed.owner, parsed.repo);
         else if (tabId === 'notifications') await fetchHubNotifs();
         panel.dataset.loaded = 'true'; panel.dataset.fetchedAt = Date.now();
-    } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: \${e.message}</div>`; }
+    } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: ${e.message}</div>`; }
 }
 
 window.fetchHubPRs = async function(owner, repo) {
     const token = getGitHubToken();
-    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
     const prs = await res.json();
-    $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${pr.title}</div><div style="font-size:11px; color:var(--text3);">#\${pr.number} por \${pr.user.login} • \${getTimeAgo(pr.updated_at)}</div></div><a href="\${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+    $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${pr.title}</div><div style="font-size:11px; color:var(--text3);">#${pr.number} por ${pr.user.login} • ${getTimeAgo(pr.updated_at)}</div></div><a href="${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
     $('pr-badge').textContent = prs.length;
 }
 
 window.fetchHubIssues = async function(owner, repo) {
     const token = getGitHubToken();
-    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
     const items = await res.json(); const issues = items.filter(i => !i.pull_request);
-    $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${issue.title}</div><div style="font-size:11px; color:var(--text3);">#\${issue.number} • \${getTimeAgo(issue.created_at)}</div></div><a href="\${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+    $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${issue.title}</div><div style="font-size:11px; color:var(--text3);">#${issue.number} • ${getTimeAgo(issue.created_at)}</div></div><a href="${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
     $('issues-badge').textContent = issues.length;
 }
 
 window.fetchHubBranches = async function(owner, repo) {
     const token = getGitHubToken();
-    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
     const branches = await res.json();
-    $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">\${b.name}</span>\${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+    $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">${b.name}</span>${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
 }
 
 window.fetchHubActions = async function(owner, repo) {
     const token = getGitHubToken();
-    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
     const data = await res.json();
     $('panel-actions').innerHTML = (data.workflow_runs || []).map(run => {
         const color = run.conclusion === 'success' ? 'var(--green)' : run.conclusion === 'failure' ? 'var(--red)' : 'var(--amber)';
-        return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:\${color}">●</span> \${run.name} #\${run.run_number}</div><div style="font-size:11px; color:var(--text3);">\${run.head_branch} • \${getTimeAgo(run.updated_at)}</div></div><a href="\${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+        return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:${color}">●</span> ${run.name} #${run.run_number}</div><div style="font-size:11px; color:var(--text3);">${run.head_branch} • ${getTimeAgo(run.updated_at)}</div></div><a href="${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
     }).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin runs</div>';
 }
 
 window.fetchHubNotifs = async function() {
     const token = getGitHubToken();
-    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+    const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
     const notifs = await res.json();
-    $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">\${n.repository.name}</div><div style="font-weight:600; color:var(--text);">\${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+    $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">${n.repository.name}</div><div style="font-weight:600; color:var(--text);">${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
     $('notif-badge-hub').textContent = notifs.length;
 }

--- a/assets/javascript/jules-panel-kanban.js
+++ b/assets/javascript/jules-panel-kanban.js
@@ -73,18 +73,18 @@ window.onDragStart = (e, sessionId) => {
 
 window.onDragOver = (e, colId) => {
     e.preventDefault();
-    const col = $(`col-\${colId}`);
+    const col = $(`col-${colId}`);
     if (col) col.classList.add('drag-over');
 };
 
 window.onDragLeave = (colId) => {
-    const col = $(`col-\${colId}`);
+    const col = $(`col-${colId}`);
     if (col) col.classList.remove('drag-over');
 };
 
 window.onDrop = async (e, targetColId) => {
     e.preventDefault();
-    const col = $(`col-\${targetColId}`);
+    const col = $(`col-${targetColId}`);
     if (col) col.classList.remove('drag-over');
 
     const sid = e.dataTransfer.getData('text/plain');
@@ -184,7 +184,7 @@ window.relaunchJules = (sessionJson) => {
                     const sessCtx = $('sess-ctx');
                     if(sessCtx) {
                         const repoLabel = $('repo-label').textContent;
-                        sessCtx.textContent = `\${repoLabel}: \${branch}`;
+                        sessCtx.textContent = `${repoLabel}: ${branch}`;
                     }
                 } else {
                     setTimeout(setBranch, 100);
@@ -327,7 +327,7 @@ window.loadJulesKanban = async function(sessions = null) {
         localStorage.setItem('jules_internal_archive', JSON.stringify(localArchive));
 
         Object.keys(colItems).forEach(colId => {
-            const colEl = $(`kb-\${colId}`), countEl = $(`kb-count-\${colId}`), mCountEl = $(`m-count-\${colId}`);
+            const colEl = $(`kb-${colId}`), countEl = $(`kb-count-${colId}`), mCountEl = $(`m-count-${colId}`);
             if (!colEl) return;
 
             const items = colItems[colId];
@@ -349,22 +349,22 @@ window.loadJulesKanban = async function(sessions = null) {
                 const canDrag = (colId === 'pending' || colId === 'running') && !isArchived;
 
                 return `
-                    <div class="kb-card \${colId} \${isArchived ? 'archived' : ''}"
-                         \${canDrag ? `draggable="true" ondragstart="onDragStart(event, '\${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
-                         onclick="openDrawer('\${s.name}')">
+                    <div class="kb-card ${colId} ${isArchived ? 'archived' : ''}"
+                         ${canDrag ? `draggable="true" ondragstart="onDragStart(event, '${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+                         onclick="openDrawer('${s.name}')">
                         <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:5px">
-                            <div class="kb-card-id">#\${sid}\${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
-                            <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${s.state}</span>
+                            <div class="kb-card-id">#${sid}${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+                            <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${s.state}</span>
                         </div>
-                        <div class="kb-card-task">\${escapeHtml(s.title || s.prompt)}</div>
+                        <div class="kb-card-task">${escapeHtml(s.title || s.prompt)}</div>
                         <div class="kb-card-meta">
-                            <span class="kb-card-repo">\${repo}</span>
-                            <span class="kb-card-time">\${getTimeAgo(s.createTime)}</span>
+                            <span class="kb-card-repo">${repo}</span>
+                            <span class="kb-card-time">${getTimeAgo(s.createTime)}</span>
                         </div>
                         <div class="kb-card-actions">
-                            \${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('\${archiveId}')">Restaurar</button>` : ''}
-                            <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('\${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
-                            <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '\${sid}'); localStorage.setItem('hy_neural_session_id', '\${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+                            ${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('${archiveId}')">Restaurar</button>` : ''}
+                            <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+                            <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '${sid}'); localStorage.setItem('hy_neural_session_id', '${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
                         </div>
                     </div>
                 `;
@@ -376,7 +376,7 @@ window.loadJulesKanban = async function(sessions = null) {
 }
 
 window.scrollToKanbanCol = function(colId, btn) {
-    const col = $(`col-\${colId}`);
+    const col = $(`col-${colId}`);
     if (col) {
         col.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
         document.querySelectorAll('#view-kanban .fpill').forEach(p => p.classList.remove('active'));

--- a/assets/javascript/jules-panel-metrics.js
+++ b/assets/javascript/jules-panel-metrics.js
@@ -13,8 +13,8 @@ window.loadJulesMetrics = async function() {
         const active = sessions.filter(s => ["WORKING", "IN_PROGRESS", "QUEUED", "PLANNING", "AWAITING_PLAN_APPROVAL"].includes(s.state)).length;
         const successRate = total > 0 ? Math.round((completed / (completed + failed || 1)) * 100) : 0;
         const totalTokens = sessions.reduce((acc, s) => acc + (s.usage?.totalTokens || 0), 0);
-        if($("m-success-rate")) $("m-success-rate").textContent = `\${successRate}%`;
-        if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `\${Math.round(totalTokens/1000)}k` : totalTokens;
+        if($("m-success-rate")) $("m-success-rate").textContent = `${successRate}%`;
+        if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `${Math.round(totalTokens/1000)}k` : totalTokens;
         if($("s-total")) $("s-total").textContent = total;
         if($("s-active")) $("s-active").textContent = active;
         if($("leg-done")) $("leg-done").textContent = completed;
@@ -23,10 +23,10 @@ window.loadJulesMetrics = async function() {
         if($("leg-pending")) $("leg-pending").textContent = sessions.filter(s => s.state === "QUEUED" || s.state === "PLANNING").length;
         const doneP = (completed / total) * 100;
         const errorP = (failed / total) * 100;
-        if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `\${doneP} 100`);
+        if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `${doneP} 100`);
         if($("donut-error")) {
-            $("donut-error").setAttribute("stroke-dasharray", `\${errorP} 100`);
-            $("donut-error").setAttribute("stroke-dashoffset", `-\${doneP}`);
+            $("donut-error").setAttribute("stroke-dasharray", `${errorP} 100`);
+            $("donut-error").setAttribute("stroke-dashoffset", `-${doneP}`);
         }
     } catch (e) {
         console.warn("[Jules] loadJulesMetrics error:", e);

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -16,7 +16,7 @@ window.saveSessionsV2 = function(skipSync = false) {
                 messages: window.chatV2Messages,
                 updatedAt: new Date().toISOString()
             };
-            localStorage.setItem(`hy_neural_context_\${sessionId}`, JSON.stringify(sessionData));
+            localStorage.setItem(`hy_neural_context_${sessionId}`, JSON.stringify(sessionData));
 
             // Sync via BroadcastChannel (nuevo formato NEW_MESSAGE)
             if (window.neuralSyncChannel && !skipSync && window.chatV2Messages.length > 0) {
@@ -51,7 +51,7 @@ window.loadV2Messages = function() {
     try {
         const sessionId = getLinkedJulesSessionId();
         if (sessionId) {
-            const saved = localStorage.getItem(`hy_neural_context_\${sessionId}`);
+            const saved = localStorage.getItem(`hy_neural_context_${sessionId}`);
             if (saved) {
                 const sessionData = JSON.parse(saved);
                 window.chatV2Messages = sessionData.messages || [];
@@ -79,16 +79,16 @@ window.loadV2Messages = function() {
 }
 
 window.triggerAutomatedAnalysis = async function(output) {
-    const analyzedKey = `v2_jules_analyzed_\${output.session_id}_\${output.status}`;
+    const analyzedKey = `v2_jules_analyzed_${output.session_id}_${output.status}`;
     if (localStorage.getItem(analyzedKey)) return;
     localStorage.setItem(analyzedKey, 'true');
 
-    window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #\${output.session_id})...` });
+    window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #${output.session_id})...` });
     renderChatV2Messages();
 
     try {
         const config = getActiveConfig();
-        const prompt = `Jules ha completado una operación (Estado: \${output.status}).\n\nDETALLES:\n- Sesión: #\${output.session_id}\n- Tarea: \${output.title}\n- Repo: \${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+        const prompt = `Jules ha completado una operación (Estado: ${output.status}).\n\nDETALLES:\n- Sesión: #${output.session_id}\n- Tarea: ${output.title}\n- Repo: ${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
 
         const messages = [
             { role: 'system', content: 'Eres un analista de operaciones de agentes autónomos.' },
@@ -96,7 +96,7 @@ window.triggerAutomatedAnalysis = async function(output) {
         ];
 
         const analysis = await callCustomProvider(config, messages);
-        window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n\${analysis}` });
+        window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n${analysis}` });
         renderChatV2Messages();
     } catch(e) {
         console.error("Auto-analysis failed", e);
@@ -109,7 +109,7 @@ window.showChatLiveActivity = function(tel) {
     if (!monitor || !status) return;
 
     monitor.classList.remove('hidden');
-    status.textContent = `[\${tel.tag}] \${tel.msg}`;
+    status.textContent = `[${tel.tag}] ${tel.msg}`;
 
     if (window.activityTimeout) clearTimeout(window.activityTimeout);
     window.activityTimeout = setTimeout(() => {
@@ -122,21 +122,21 @@ window.buildSystemPrompt = async function(userMessage, basePrompt) {
 
     const t = window.JulesPanelState.activePayload?.source_task;
     if (t) {
-        const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: \${t.blocks.join(', ')}` : 'No bloquea a nadie';
-        const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: \${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+        const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: ${t.blocks.join(', ')}` : 'No bloquea a nadie';
+        const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: ${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
 
         systemPrompt += `\n\n## Tarea activa en contexto\n` +
-            `ID: #\${t.id}\n` +
-            `Título: \${t.titulo || t.title}\n` +
-            `Descripción: \${t.descripcion || t.description}\n` +
-            `Criterios de Aceptación: \${t.acceptance_criteria || 'N/A'}\n` +
-            `Subtareas: \${JSON.stringify(t.subtasks || [])}\n` +
-            `Estado: \${t.estado || t.status}\n` +
-            `Prioridad: \${t.prioridad || t.priority}\n` +
-            `Rama: \${t.rama || 'N/A'}\n` +
-            `Milestone: \${t.milestone || 'N/A'}\n` +
-            `Repositorio: \${t.repository || t.repo || 'N/A'}\n` +
-            `Dependencias: \${blockingInfo} | \${blockedByInfo}\n`;
+            `ID: #${t.id}\n` +
+            `Título: ${t.titulo || t.title}\n` +
+            `Descripción: ${t.descripcion || t.description}\n` +
+            `Criterios de Aceptación: ${t.acceptance_criteria || 'N/A'}\n` +
+            `Subtareas: ${JSON.stringify(t.subtasks || [])}\n` +
+            `Estado: ${t.estado || t.status}\n` +
+            `Prioridad: ${t.prioridad || t.priority}\n` +
+            `Rama: ${t.rama || 'N/A'}\n` +
+            `Milestone: ${t.milestone || 'N/A'}\n` +
+            `Repositorio: ${t.repository || t.repo || 'N/A'}\n` +
+            `Dependencias: ${blockingInfo} | ${blockedByInfo}\n`;
 
         const linkedSid = getLinkedJulesSessionId();
         if (linkedSid) {
@@ -144,7 +144,7 @@ window.buildSystemPrompt = async function(userMessage, basePrompt) {
                 const activities = await window.julesApi.getActivities(linkedSid, 10);
                 const logs = (activities.activities || []).map(a => a.description || a.progressUpdated?.title).filter(Boolean).join('\n');
                 if (logs) {
-                    systemPrompt += `\n### Historial reciente de Jules (Sesión #\${linkedSid}):\n\${logs}\n`;
+                    systemPrompt += `\n### Historial reciente de Jules (Sesión #${linkedSid}):\n${logs}\n`;
                 }
             } catch (e) { console.warn("Could not fetch Jules activity for context", e); }
         }
@@ -165,7 +165,7 @@ window.callCustomProvider = async function(config, messages) {
     const baseUrl = (config.base_url || "https://api.anthropic.com/v1").replace(/\/$/, "");
     const isAnthropic = baseUrl.includes("anthropic.com");
     const isOllama = baseUrl.includes("localhost") || baseUrl.includes("127.0.0.1");
-    const endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+    const endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
     const apiKey = config.api_key || config.apiKey || "";
     const headers = { "Content-Type": "application/json" };
     let body = {};
@@ -180,7 +180,7 @@ window.callCustomProvider = async function(config, messages) {
             messages: messages.filter(m => m.role !== "system")
         };
     } else {
-        if (!isOllama) headers["Authorization"] = `Bearer \${apiKey}`;
+        if (!isOllama) headers["Authorization"] = `Bearer ${apiKey}`;
         body = {
             model: config.model || "llama3",
             messages: messages,
@@ -188,7 +188,7 @@ window.callCustomProvider = async function(config, messages) {
         };
     }
     const res = await fetch(endpoint, { method: "POST", headers, body: JSON.stringify(body) });
-    if (!res.ok) throw new Error(`API Error: \${res.status}`);
+    if (!res.ok) throw new Error(`API Error: ${res.status}`);
     const data = await res.json();
     return isAnthropic ? data.content[0].text : data.choices[0].message.content;
 }
@@ -279,7 +279,7 @@ window.sendChatV2Msg = async function(retryCount = 0) {
         sendBtn.disabled = true;
 
         if (thinking) {
-            thinking.textContent = retryCount > 0 ? `REINTENTANDO (\${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+            thinking.textContent = retryCount > 0 ? `REINTENTANDO (${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
             thinking.classList.remove('hidden');
         }
 
@@ -296,12 +296,12 @@ window.sendChatV2Msg = async function(retryCount = 0) {
             let finalMessages = window.chatV2Messages.filter(m => ['user', 'assistant', 'jules'].includes(m.role))
                 .map(m => ({
                     role: m.role === 'jules' ? 'user' : (m.role === 'assistant' ? 'assistant' : 'user'),
-                    content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n\${m.content}` : m.content
+                    content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n${m.content}` : m.content
                 }));
 
             if (window.JulesPanelState.activePayload?.source_task) {
                 const t = window.JulesPanelState.activePayload.source_task;
-                const contextPrefix = `[CONTEXTO TAREA #\${t.id}: \${t.titulo}]\n`;
+                const contextPrefix = `[CONTEXTO TAREA #${t.id}: ${t.titulo}]\n`;
                 if (finalMessages.length > 0 && finalMessages[finalMessages.length - 1].role === 'user') {
                     finalMessages[finalMessages.length - 1].content = contextPrefix + finalMessages[finalMessages.length - 1].content;
                 }
@@ -318,7 +318,7 @@ window.sendChatV2Msg = async function(retryCount = 0) {
                 baseUrl += '/v1';
             }
 
-            let endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+            let endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
 
             const headers = {
                 'Content-Type': 'application/json',
@@ -327,7 +327,7 @@ window.sendChatV2Msg = async function(retryCount = 0) {
                     'anthropic-version': '2023-06-01',
                     'anthropic-dangerous-direct-browser-access': 'true'
                 } : (!isOllama ? {
-                    'Authorization': `Bearer \${apiKey}`
+                    'Authorization': `Bearer ${apiKey}`
                 } : {}))
             };
 
@@ -357,7 +357,7 @@ window.sendChatV2Msg = async function(retryCount = 0) {
 
             if (!res.ok) {
                 const errData = await res.json().catch(() => ({}));
-                throw new Error(errData.error?.message || `HTTP \${res.status}`);
+                throw new Error(errData.error?.message || `HTTP ${res.status}`);
             }
 
             await consumeStreamV2(res, config.provider || (isAnthropic ? 'anthropic' : 'custom'));
@@ -365,11 +365,11 @@ window.sendChatV2Msg = async function(retryCount = 0) {
         } catch (e) {
             console.error('[ChatV2] Error:', e);
             if ((e.name === 'AbortError' || e.message.toLowerCase().includes('timeout')) && retryCount < 2) {
-                addTel("SYSTEM", `Reintentando comunicación (\${retryCount + 1}/2)...`, "warn");
+                addTel("SYSTEM", `Reintentando comunicación (${retryCount + 1}/2)...`, "warn");
                 return sendChatV2Msg(retryCount + 1);
             }
             showToast("Error en comunicación con Claude", "red");
-            window.chatV2Messages.push({ role: 'system', content: `❌ Error: \${e.message}` });
+            window.chatV2Messages.push({ role: 'system', content: `❌ Error: ${e.message}` });
             saveSessionsV2();
             renderChatV2Messages();
         } finally {
@@ -426,7 +426,7 @@ window.consumeStreamV2 = async function(response, provider) {
                     if (aiContent || thinkingContent) {
                         let finalHtml = '';
                         if (thinkingContent) {
-                            finalHtml += `<div class="thinking-block">\${escapeHtml(thinkingContent)}</div>`;
+                            finalHtml += `<div class="thinking-block">${escapeHtml(thinkingContent)}</div>`;
                         }
                         if (aiContent) {
                             finalHtml += marked.parse(aiContent);
@@ -492,7 +492,7 @@ window.renderChatV2Messages = function() {
 
     container.innerHTML = window.chatV2Messages.map((m, idx) => {
         if (m.role === 'system') {
-            return `<div class="message-system">\${m.content}</div>`;
+            return `<div class="message-system">${m.content}</div>`;
         }
 
         let label = 'CLAUDE';
@@ -514,13 +514,13 @@ window.renderChatV2Messages = function() {
         }
 
         return `
-        <div class="\${roleClass}">
-            <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: \${labelColor}">
-                \${label}
+        <div class="${roleClass}">
+            <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: ${labelColor}">
+                ${label}
             </div>
             <div class="prose-invert" style="font-size: 13.5px; line-height: 1.6;">
-                \${m.thinking ? `<div class="thinking-block">\${escapeHtml(m.thinking)}</div>` : ''}
-                \${marked.parse(m.content)}
+                ${m.thinking ? `<div class="thinking-block">${escapeHtml(m.thinking)}</div>` : ''}
+                ${marked.parse(m.content)}
             </div>
         </div>`;
     }).join('');
@@ -548,45 +548,45 @@ window.renderSessionDrawerList = function() {
         const statusColor = isActive ? 'var(--green)' : 'var(--text3)';
         return `
         <div style="background: var(--surface2); border: 1px solid var(--border); border-radius: var(--r-md); padding: 16px; transition: all var(--t-fast); position: relative; overflow: hidden;">
-            \${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+            ${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
             <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px;">
                 <div style="min-width: 0; flex: 1;">
-                    <div id="drawer-name-display-\${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('\${s.id}')">
-                        \${s.name}
+                    <div id="drawer-name-display-${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('${s.id}')">
+                        ${s.name}
                     </div>
-                    <input id="drawer-name-edit-\${s.id}" type="text" class="cfg-input hidden" value="\${s.name}" onblur="saveRenameFromDrawer('\${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+                    <input id="drawer-name-edit-${s.id}" type="text" class="cfg-input hidden" value="${s.name}" onblur="saveRenameFromDrawer('${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
                     <div style="display: flex; align-items: center; gap: 8px; margin-top: 4px;">
-                        <span style="font-size: 9px; color: \${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
-                            \${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} \${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+                        <span style="font-size: 9px; color: ${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+                            ${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} ${isActive ? 'ACTIVA' : 'ARCHIVADA'}
                         </span>
-                        <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#\${s.id}</span>
+                        <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#${s.id}</span>
                     </div>
                 </div>
                 <div style="display: flex; gap: 6px;">
-                    <button onclick="renameFromDrawer('\${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
-                    <button onclick="archiveFromDrawer('\${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); \${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
-                    <button onclick="deleteFromDrawer('\${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+                    <button onclick="renameFromDrawer('${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+                    <button onclick="archiveFromDrawer('${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); ${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+                    <button onclick="deleteFromDrawer('${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
                 </div>
             </div>
             <div style="display: flex; justify-content: space-between; align-items: center; font-size: 10px; color: var(--text2); font-family: var(--font-mono); margin-top: 4px; padding-top: 10px; border-top: 1px solid var(--border);">
                 <span style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; display: flex; align-items: center; gap: 6px;">
-                    <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> \${s.task_title}
+                    <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> ${s.task_title}
                 </span>
-                <span style="color: var(--text3);">\${new Date(s.start).toLocaleDateString()}</span>
+                <span style="color: var(--text3);">${new Date(s.start).toLocaleDateString()}</span>
             </div>
         </div>`;
     }).join('');
 }
 
 window.renameFromDrawer = (sid) => {
-    $(`drawer-name-display-\${sid}`).classList.add('hidden');
-    const edit = $(`drawer-name-edit-\${sid}`);
+    $(`drawer-name-display-${sid}`).classList.add('hidden');
+    const edit = $(`drawer-name-edit-${sid}`);
     edit.classList.remove('hidden');
     edit.focus();
 };
 
 window.saveRenameFromDrawer = (sid) => {
-    const edit = $(`drawer-name-edit-\${sid}`);
+    const edit = $(`drawer-name-edit-${sid}`);
     const newName = edit.value.trim();
     if (newName) {
         const sessions = JSON.parse(localStorage.getItem('hy_neural_sessions') || '[]');
@@ -634,7 +634,7 @@ window.restoreSessionFromDrawer = (sid) => {
     localStorage.setItem('hy_neural_active', s.status === 'active' ? 'true' : 'false');
     const claudeId = localStorage.getItem('hy_active_claude_session_id');
     if (claudeId) {
-        localStorage.setItem(`hy_neural_session_id_\${claudeId}`, s.id);
+        localStorage.setItem(`hy_neural_session_id_${claudeId}`, s.id);
     }
     localStorage.setItem('hy_neural_session_id', s.id);
     localStorage.setItem('hy_neural_session_name', s.name);

--- a/assets/javascript/jules-panel-repo.js
+++ b/assets/javascript/jules-panel-repo.js
@@ -71,7 +71,7 @@ window.renderRepos = function(sources) {
             el.style.opacity = '0.5';
             el.style.cursor = 'not-allowed';
         }
-        el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">\${s.displayName || s.name.split('/').pop()}</span>\${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+        el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">${s.displayName || s.name.split('/').pop()}</span>${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
         if (isInstalled) {
             el.onclick = () => switchRepo(s.name, s);
         }
@@ -85,8 +85,8 @@ window.switchRepo = function(sourceName, sourceObj) {
     localStorage.setItem('hypenosys_active_repo', sourceName);
     renderRepos(window.julesSourcesCache || []);
     onRepoSelected(sourceName, sourceObj);
-    if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → \${sourceName.split('/').pop()}`, "info");
-    else addTel("SYSTEM", `Contexto: \${sourceName.split('/').pop()}`, "info");
+    if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → ${sourceName.split('/').pop()}`, "info");
+    else addTel("SYSTEM", `Contexto: ${sourceName.split('/').pop()}`, "info");
 }
 
 window.onRepoSelected = async function(sourceName, sourceObject) {
@@ -97,7 +97,7 @@ window.onRepoSelected = async function(sourceName, sourceObject) {
     if(cfgPath) cfgPath.textContent = sourceName;
     const displayLabel = sourceObject?.displayName || repoName;
     if(aliasIn) aliasIn.value = window.getRepoAlias(sourceName) || displayLabel;
-    if(sessCtx) sessCtx.textContent = `\${displayLabel}: cargando...`;
+    if(sessCtx) sessCtx.textContent = `${displayLabel}: cargando...`;
     branchSelect.disabled = true;
     branchSelect.innerHTML = '<option value="">Cargando ramas...</option>';
     branchSelect.onchange = (e) => {
@@ -107,7 +107,7 @@ window.onRepoSelected = async function(sourceName, sourceObject) {
         const sessCtx = $('sess-ctx');
         if(sessCtx) {
             const repoLabel = $('repo-label').textContent;
-            sessCtx.textContent = `\${repoLabel}: \${e.target.value}`;
+            sessCtx.textContent = `${repoLabel}: ${e.target.value}`;
         }
         checkBranchWarning();
     };
@@ -115,12 +115,12 @@ window.onRepoSelected = async function(sourceName, sourceObject) {
         const branches = await window.githubContext.getBranches(repoName, repoOwner || undefined);
         const repoData = (await window.githubContext.getRepos()).find(r => r.name === repoName && (repoOwner ? r.owner === repoOwner : true));
         const defaultBranch = repoData ? repoData.default_branch : 'main';
-        branchSelect.innerHTML = branches.map(b => `<option value="\${b.name}" \${b.name === defaultBranch ? 'selected' : ''}>\${b.name}\${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+        branchSelect.innerHTML = branches.map(b => `<option value="${b.name}" ${b.name === defaultBranch ? 'selected' : ''}>${b.name}${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
         const lastSelected = localStorage.getItem('jules_selected_branch');
         if (lastSelected && branches.some(b => b.name === lastSelected)) branchSelect.value = lastSelected;
-        if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>\${branches.length} ramas</span>`;
+        if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>${branches.length} ramas</span>`;
         const activeBranch = branchSelect.value;
-        if(sessCtx) sessCtx.textContent = `\${displayLabel}: \${activeBranch}`;
+        if(sessCtx) sessCtx.textContent = `${displayLabel}: ${activeBranch}`;
         window.JulesPanelState.activeBranch = activeBranch;
         checkBranchWarning();
     } catch (e) { branchSelect.innerHTML = '<option value="main">main</option>'; }
@@ -135,13 +135,13 @@ window.populateContextSelector = async function(sources, apiFailed = false) {
         filtered.forEach(s => {
             const item = document.createElement('div');
             const isInstalled = s.isJulesInstalled || apiFailed;
-            item.className = `custom-dropdown-item \${!isInstalled ? 'disabled' : ''}`;
+            item.className = `custom-dropdown-item ${!isInstalled ? 'disabled' : ''}`;
             if (!isInstalled) {
                 item.style.opacity = '0.5';
                 item.style.cursor = 'not-allowed';
                 item.title = "Jules App no instalada";
             }
-            item.innerHTML = `<span>\${s.displayName || s.name.split('/').pop()}</span> \${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+            item.innerHTML = `<span>${s.displayName || s.name.split('/').pop()}</span> ${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
             if (isInstalled) {
                 item.onclick = (e) => { e.stopPropagation(); label.textContent = s.displayName || s.name.split('/').pop(); switchRepo(s.name, s); menu.style.display = 'none'; };
             }

--- a/assets/javascript/jules-panel-sessions.js
+++ b/assets/javascript/jules-panel-sessions.js
@@ -15,8 +15,8 @@ window.STATE_CONFIG = {
 
 window.getStateBadge = function(state) {
   const cfg = STATE_CONFIG[state] || { label: state || '—', cls: 'queued', icon: '◌' };
-  return `<span class="session-badge session-badge--\${cfg.cls}">
-    \${cfg.icon} \${cfg.label}
+  return `<span class="session-badge session-badge--${cfg.cls}">
+    ${cfg.icon} ${cfg.label}
   </span>`;
 }
 
@@ -35,7 +35,7 @@ window.refreshActivities = async function(idSafe) {
         const session = currentSessions.find(s => s.name === sessionId);
 
         // Update sticky badge
-        const stickyBadge = document.getElementById(`sticky-badge-\${idSafe}`);
+        const stickyBadge = document.getElementById(`sticky-badge-${idSafe}`);
         if (stickyBadge && session) {
             stickyBadge.innerHTML = getStateBadge(session.state);
             stickyBadge.classList.remove('hidden');
@@ -135,15 +135,15 @@ window.renderActivity = function(activity) {
           if (line.startsWith('+') && !line.startsWith('+++')) cls = 'dl dl-add';
           else if (line.startsWith('-') && !line.startsWith('---')) cls = 'dl dl-del';
           else if (line.startsWith('@@')) cls = 'dl dl-hunk';
-          return `<div class="\${cls}">\${escapeHtml(line)}</div>`;
+          return `<div class="${cls}">${escapeHtml(line)}</div>`;
         }).join('');
 
         const session = currentSessions.find(s => s.name === activity.name?.split('/activities/')[0]);
         const moreHtml = hiddenCount > 0
           ? `<div style="font-size:10px;color:#6b7280;padding:6px;text-align:center;
                border-top:1px solid #2a2a35;">
-               +\${hiddenCount} líneas más —
-               <a href="\${session?.url || '#'}" target="_blank"
+               +${hiddenCount} líneas más —
+               <a href="${session?.url || '#'}" target="_blank"
                   style="color:#8b5cf6;text-decoration:underline;">
                  ver completo en Jules
                </a>
@@ -157,13 +157,13 @@ window.renderActivity = function(activity) {
               display:flex;align-items:center;gap:6px;">
               <span>📄</span>
               <span>Ver cambios en código</span>
-              \${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
-                — \${escapeHtml(msg)}</span>` : ''}
+              ${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+                — ${escapeHtml(msg)}</span>` : ''}
             </summary>
             <div style="border:1px solid #2a2a35;border-radius:6px;
               overflow:hidden;max-height:250px;overflow-y:auto;">
-              \${diffLinesHtml}
-              \${moreHtml}
+              ${diffLinesHtml}
+              ${moreHtml}
             </div>
           </details>`;
       }
@@ -178,18 +178,18 @@ window.renderActivity = function(activity) {
         <div style="padding:8px 0;border-bottom:1px solid #1e1e2a;">
           <div style="display:flex;gap:8px;">
             <span style="color:#7c3aed;font-weight:700;min-width:18px;">
-              \${(s.index || 0) + 1}.
+              ${(s.index || 0) + 1}.
             </span>
             <div style="flex: 1;">
               <div style="color:#e2e8f0;font-size:12px;font-weight:500;">
-                \${s.title || 'Sin título'}
+                ${s.title || 'Sin título'}
               </div>
-              \${s.description ? `
+              ${s.description ? `
                 <div style="color:#6b7280;font-size:11px;margin-top:2px;">
-                  \${s.description}
+                  ${s.description}
                 </div>` : ''}
             </div>
-            <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('\${activity.name?.split('/activities/')[0]}', \${(s.index || 0) + 1}, '\${escapeHtml(s.title)}')">
+            <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('${activity.name?.split('/activities/')[0]}', ${(s.index || 0) + 1}, '${escapeHtml(s.title)}')">
               <i class="fa-solid fa-comment-dots text-[10px]"></i>
             </button>
           </div>
@@ -200,9 +200,9 @@ window.renderActivity = function(activity) {
       <div class="activity-entry activity-entry--plan">
         <div style="font-size:10px;font-weight:700;color:#8b5cf6;
                     text-transform:uppercase;letter-spacing:1px;margin-bottom:6px;">
-          📋 Plan generado (\${steps.length} pasos)
+          📋 Plan generado (${steps.length} pasos)
         </div>
-        <div>\${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+        <div>${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
       </div>`;
   }
   else if (activity.planApproved) {
@@ -213,12 +213,12 @@ window.renderActivity = function(activity) {
   else if (activity.userMessaged) {
     const msg = activity.userMessaged.userMessage || '';
     const parsed = typeof marked !== 'undefined' ? marked.parse(msg) : escapeHtml(msg);
-    html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+    html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
   }
   else if (activity.agentMessaged) {
     const msg = activity.agentMessaged.agentMessage || '';
     const parsed = typeof marked !== 'undefined' ? marked.parse(msg) : escapeHtml(msg);
-    html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+    html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
   }
   else if (activity.progressUpdated) {
     const title = activity.progressUpdated.title || '';
@@ -232,18 +232,18 @@ window.renderActivity = function(activity) {
       <div class="activity-entry activity-entry--progress">
         <div class="prose-invert" style="overflow-x:auto;max-width:100%;word-break:break-word;font-size:12px;">
           <span style="color:#8b5cf6;font-weight:700;">⚙️</span>
-          \${parsedTitle}
-          \${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">\${parsedDesc}</div>` : ''}
+          ${parsedTitle}
+          ${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">${parsedDesc}</div>` : ''}
         </div>
-        \${bash ? `
+        ${bash ? `
           <details style="margin-top:6px;">
             <summary style="font-size:10px;color:#6b7280;cursor:pointer;">
-              $ \${escapeHtml(bash.command || '')}
-              <span style="color:\${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
-                [exit \${bash.exitCode ?? '?'}]
+              $ ${escapeHtml(bash.command || '')}
+              <span style="color:${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+                [exit ${bash.exitCode ?? '?'}]
               </span>
             </summary>
-            <pre class="activity-code">\${escapeHtml(bash.output || "")}</pre>
+            <pre class="activity-code">${escapeHtml(bash.output || "")}</pre>
           </details>` : ''}
       </div>`;
   }
@@ -257,11 +257,11 @@ window.renderActivity = function(activity) {
     html = `
       <div class="activity-entry" style="color:#10b981;font-size:11px;font-weight:600;">
         🏁 Sesión completada
-        \${parsed ? `
+        ${parsed ? `
           <div class="prose-invert" style="overflow-x:auto;max-width:100%;word-break:break-word;
                font-size:11px;font-weight:400;color:#d1d5db;margin-top:6px;
                border-top:1px solid #1e1e2a;padding-top:6px;">
-            \${parsed}
+            ${parsed}
           </div>` : ''}
       </div>`;
   }
@@ -269,7 +269,7 @@ window.renderActivity = function(activity) {
     const reason = activity.sessionFailed.reason || 'Error desconocido';
     html = `<div class="activity-entry"
                      style="color:#ef4444;font-size:11px;">
-      ❌ Sesión fallida: \${escapeHtml(reason)}
+      ❌ Sesión fallida: ${escapeHtml(reason)}
     </div>`;
   }
 
@@ -279,7 +279,7 @@ window.renderActivity = function(activity) {
     if (desc) {
       html = `<div class="activity-entry" style="color:#4b5563;font-size:10px;
         font-style:italic;">
-        \${escapeHtml(desc)}
+        ${escapeHtml(desc)}
       </div>`;
     }
   }
@@ -310,7 +310,7 @@ window.updateApprovalStatus = function(activities, sessionId) {
     if (needsApproval) {
         const btnHtml = `
             <span style="font-size: 11px; color: var(--amber); font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;">Plan pendiente de aprobación</span>
-            <button onclick="approveJulesPlan('\${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+            <button onclick="approveJulesPlan('${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
                 <i class="fas fa-check mr-2"></i> APROBAR PLAN
             </button>
         `;
@@ -422,7 +422,7 @@ window.renderHistoryTable = function(sessions) {
     // Desktop Table
     body.innerHTML = sessions.map(s => {
         const statusLabel = { 'IN_PROGRESS': 'activo', 'COMPLETED': 'listo', 'FAILED': 'error', 'QUEUED': 'cola', 'PLANNING': 'planificando', 'AWAITING_PLAN_APPROVAL': 'esperando' }[s.state] || 'listo';
-        return `<tr onclick="openDrawer('\${s.name}')"><td><span class="sid">\${s.name.split('/').pop()}</span></td><td class="tdesc">\${escapeHtml(s.title || s.prompt)}</td><td class="tmono">\${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">\${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>\${statusLabel}</span></td><td class="tmono">\${getTimeAgo(s.createTime)}</td><td class="tmono">\${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+        return `<tr onclick="openDrawer('${s.name}')"><td><span class="sid">${s.name.split('/').pop()}</span></td><td class="tdesc">${escapeHtml(s.title || s.prompt)}</td><td class="tmono">${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>${statusLabel}</span></td><td class="tmono">${getTimeAgo(s.createTime)}</td><td class="tmono">${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
     }).join('');
 
     // Mobile compact list
@@ -431,15 +431,15 @@ window.renderHistoryTable = function(sessions) {
       mobList.innerHTML = sessions.map(s => {
         const statusLabel = { 'IN_PROGRESS': 'activo', 'COMPLETED': 'listo', 'FAILED': 'error', 'QUEUED': 'cola', 'PLANNING': 'planificando', 'AWAITING_PLAN_APPROVAL': 'esperando' }[s.state] || 'listo';
         return `
-          <div onclick="openDrawer('\${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+          <div onclick="openDrawer('${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
             <div style="display:flex; justify-content:space-between; align-items:center">
-              <span class="sid">\${s.name.split('/').pop()}</span>
-              <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${statusLabel}</span>
+              <span class="sid">${s.name.split('/').pop()}</span>
+              <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${statusLabel}</span>
             </div>
-            <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">\${escapeHtml(s.title || s.prompt)}</div>
+            <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">${escapeHtml(s.title || s.prompt)}</div>
             <div style="display:flex; justify-content:space-between; font-size:11px; color:var(--text3)">
-              <span>\${s.sourceContext?.source?.split('/').pop() || '---'}</span>
-              <span>\${getTimeAgo(s.createTime)}</span>
+              <span>${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+              <span>${getTimeAgo(s.createTime)}</span>
             </div>
           </div>
         `;
@@ -493,37 +493,37 @@ window.analyzeSelectedWithClaude = function() {
         let activityType = "Actividad";
         if (act.userMessaged) activityType = "Mensaje del Usuario";
         else if (act.agentMessaged) activityType = "Mensaje de Jules";
-        else if (act.progressUpdated) activityType = `Progreso: \${act.progressUpdated.title}`;
+        else if (act.progressUpdated) activityType = `Progreso: ${act.progressUpdated.title}`;
         else if (act.planGenerated) activityType = "Plan Generado";
         else if (act.sessionCompleted) activityType = "Sesión Completada";
         else if (act.sessionFailed) activityType = "Sesión Fallida";
         else if (act.description) activityType = act.description;
 
-        const separator = `\n--- Actividad: \${activityType} ---\n`;
+        const separator = `\n--- Actividad: ${activityType} ---\n`;
         let content = "";
 
         if (act.userMessaged) {
-            content += `\${act.userMessaged.userMessage}\n`;
+            content += `${act.userMessaged.userMessage}\n`;
         } else if (act.agentMessaged) {
-            content += `\${act.agentMessaged.agentMessage}\n`;
+            content += `${act.agentMessaged.agentMessage}\n`;
         } else if (act.progressUpdated) {
-            if (act.progressUpdated.description) content += `\${act.progressUpdated.description}\n`;
+            if (act.progressUpdated.description) content += `${act.progressUpdated.description}\n`;
         } else if (act.planGenerated) {
             const steps = act.planGenerated.plan?.steps || [];
-            content += `PASOS:\n\${steps.map(s => `\${(s.index || 0) + 1}. \${s.title}: \${s.description || ''}`).join('\n')}\n`;
+            content += `PASOS:\n${steps.map(s => `${(s.index || 0) + 1}. ${s.title}: ${s.description || ''}`).join('\n')}\n`;
         } else if (act.sessionCompleted) {
-            content += `Commit: \${act.sessionCompleted.commitMessage || '---'}\n`;
+            content += `Commit: ${act.sessionCompleted.commitMessage || '---'}\n`;
         } else if (act.sessionFailed) {
-            content += `Razón: \${act.sessionFailed.reason || 'Desconocida'}\n`;
+            content += `Razón: ${act.sessionFailed.reason || 'Desconocida'}\n`;
         }
 
         if (act.artifacts) {
             act.artifacts.forEach(art => {
                 if (art.changeSet?.gitPatch?.unidiffPatch) {
-                    content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n\${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+                    content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
                 }
                 if (art.bashOutput) {
-                    content += `\nCOMANDO: \${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n\${art.bashOutput.output}\n\`\`\`\n`;
+                    content += `\nCOMANDO: ${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n${art.bashOutput.output}\n\`\`\`\n`;
                 }
             });
         }
@@ -557,7 +557,7 @@ window.commentOnStep = function(sessionId, stepIndex, stepTitle) {
     const idSafe = getIdSafe(sessionId);
     const input = document.getElementById(`v2-chat-input`);
     if (input) {
-        input.value = `Respecto al paso \${stepIndex} (\${stepTitle}): ` + input.value;
+        input.value = `Respecto al paso ${stepIndex} (${stepTitle}): ` + input.value;
         input.scrollIntoView({ behavior: 'smooth', block: 'center' });
         input.focus();
     }

--- a/audit_full.txt
+++ b/audit_full.txt
@@ -1,0 +1,875 @@
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 74
+BEFORE: el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">\${s.displayName || s.name.split('/').pop()}</span>\${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+AFTER: el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">${s.displayName || s.name.split('/').pop()}</span>${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 88
+BEFORE: if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → \${sourceName.split('/').pop()}`, "info");
+AFTER: if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → ${sourceName.split('/').pop()}`, "info");
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 89
+BEFORE: else addTel("SYSTEM", `Contexto: \${sourceName.split('/').pop()}`, "info");
+AFTER: else addTel("SYSTEM", `Contexto: ${sourceName.split('/').pop()}`, "info");
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 100
+BEFORE: if(sessCtx) sessCtx.textContent = `\${displayLabel}: cargando...`;
+AFTER: if(sessCtx) sessCtx.textContent = `${displayLabel}: cargando...`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 110
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${e.target.value}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${e.target.value}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 118
+BEFORE: branchSelect.innerHTML = branches.map(b => `<option value="\${b.name}" \${b.name === defaultBranch ? 'selected' : ''}>\${b.name}\${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+AFTER: branchSelect.innerHTML = branches.map(b => `<option value="${b.name}" ${b.name === defaultBranch ? 'selected' : ''}>${b.name}${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 121
+BEFORE: if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>\${branches.length} ramas</span>`;
+AFTER: if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>${branches.length} ramas</span>`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 123
+BEFORE: if(sessCtx) sessCtx.textContent = `\${displayLabel}: \${activeBranch}`;
+AFTER: if(sessCtx) sessCtx.textContent = `${displayLabel}: ${activeBranch}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 138
+BEFORE: item.className = `custom-dropdown-item \${!isInstalled ? 'disabled' : ''}`;
+AFTER: item.className = `custom-dropdown-item ${!isInstalled ? 'disabled' : ''}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 144
+BEFORE: item.innerHTML = `<span>\${s.displayName || s.name.split('/').pop()}</span> \${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+AFTER: item.innerHTML = `<span>${s.displayName || s.name.split('/').pop()}</span> ${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 18
+BEFORE: return `<span class="session-badge session-badge--\${cfg.cls}">
+AFTER: return `<span class="session-badge session-badge--${cfg.cls}">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 19
+BEFORE: \${cfg.icon} \${cfg.label}
+AFTER: ${cfg.icon} ${cfg.label}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 38
+BEFORE: const stickyBadge = document.getElementById(`sticky-badge-\${idSafe}`);
+AFTER: const stickyBadge = document.getElementById(`sticky-badge-${idSafe}`);
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 138
+BEFORE: return `<div class="\${cls}">\${escapeHtml(line)}</div>`;
+AFTER: return `<div class="${cls}">${escapeHtml(line)}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 145
+BEFORE: +\${hiddenCount} líneas más —
+AFTER: +${hiddenCount} líneas más —
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 146
+BEFORE: <a href="\${session?.url || '#'}" target="_blank"
+AFTER: <a href="${session?.url || '#'}" target="_blank"
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 160
+BEFORE: \${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+AFTER: ${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 161
+BEFORE: — \${escapeHtml(msg)}</span>` : ''}
+AFTER: — ${escapeHtml(msg)}</span>` : ''}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 165
+BEFORE: \${diffLinesHtml}
+AFTER: ${diffLinesHtml}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 166
+BEFORE: \${moreHtml}
+AFTER: ${moreHtml}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 181
+BEFORE: \${(s.index || 0) + 1}.
+AFTER: ${(s.index || 0) + 1}.
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 185
+BEFORE: \${s.title || 'Sin título'}
+AFTER: ${s.title || 'Sin título'}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 187
+BEFORE: \${s.description ? `
+AFTER: ${s.description ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 189
+BEFORE: \${s.description}
+AFTER: ${s.description}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 192
+BEFORE: <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('\${activity.name?.split('/activities/')[0]}', \${(s.index || 0) + 1}, '\${escapeHtml(s.title)}')">
+AFTER: <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('${activity.name?.split('/activities/')[0]}', ${(s.index || 0) + 1}, '${escapeHtml(s.title)}')">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 203
+BEFORE: 📋 Plan generado (\${steps.length} pasos)
+AFTER: 📋 Plan generado (${steps.length} pasos)
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 205
+BEFORE: <div>\${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+AFTER: <div>${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 216
+BEFORE: html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+AFTER: html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 221
+BEFORE: html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+AFTER: html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 235
+BEFORE: \${parsedTitle}
+AFTER: ${parsedTitle}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 236
+BEFORE: \${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">\${parsedDesc}</div>` : ''}
+AFTER: ${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">${parsedDesc}</div>` : ''}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 238
+BEFORE: \${bash ? `
+AFTER: ${bash ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 241
+BEFORE: $ \${escapeHtml(bash.command || '')}
+AFTER: $ ${escapeHtml(bash.command || '')}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 242
+BEFORE: <span style="color:\${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+AFTER: <span style="color:${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 243
+BEFORE: [exit \${bash.exitCode ?? '?'}]
+AFTER: [exit ${bash.exitCode ?? '?'}]
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 246
+BEFORE: <pre class="activity-code">\${escapeHtml(bash.output || "")}</pre>
+AFTER: <pre class="activity-code">${escapeHtml(bash.output || "")}</pre>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 260
+BEFORE: \${parsed ? `
+AFTER: ${parsed ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 264
+BEFORE: \${parsed}
+AFTER: ${parsed}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 272
+BEFORE: ❌ Sesión fallida: \${escapeHtml(reason)}
+AFTER: ❌ Sesión fallida: ${escapeHtml(reason)}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 282
+BEFORE: \${escapeHtml(desc)}
+AFTER: ${escapeHtml(desc)}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 313
+BEFORE: <button onclick="approveJulesPlan('\${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+AFTER: <button onclick="approveJulesPlan('${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 425
+BEFORE: return `<tr onclick="openDrawer('\${s.name}')"><td><span class="sid">\${s.name.split('/').pop()}</span></td><td class="tdesc">\${escapeHtml(s.title || s.prompt)}</td><td class="tmono">\${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">\${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>\${statusLabel}</span></td><td class="tmono">\${getTimeAgo(s.createTime)}</td><td class="tmono">\${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+AFTER: return `<tr onclick="openDrawer('${s.name}')"><td><span class="sid">${s.name.split('/').pop()}</span></td><td class="tdesc">${escapeHtml(s.title || s.prompt)}</td><td class="tmono">${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>${statusLabel}</span></td><td class="tmono">${getTimeAgo(s.createTime)}</td><td class="tmono">${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 434
+BEFORE: <div onclick="openDrawer('\${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+AFTER: <div onclick="openDrawer('${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 436
+BEFORE: <span class="sid">\${s.name.split('/').pop()}</span>
+AFTER: <span class="sid">${s.name.split('/').pop()}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 437
+BEFORE: <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${statusLabel}</span>
+AFTER: <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${statusLabel}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 439
+BEFORE: <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">\${escapeHtml(s.title || s.prompt)}</div>
+AFTER: <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">${escapeHtml(s.title || s.prompt)}</div>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 441
+BEFORE: <span>\${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+AFTER: <span>${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 442
+BEFORE: <span>\${getTimeAgo(s.createTime)}</span>
+AFTER: <span>${getTimeAgo(s.createTime)}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 496
+BEFORE: else if (act.progressUpdated) activityType = `Progreso: \${act.progressUpdated.title}`;
+AFTER: else if (act.progressUpdated) activityType = `Progreso: ${act.progressUpdated.title}`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 502
+BEFORE: const separator = `\n--- Actividad: \${activityType} ---\n`;
+AFTER: const separator = `\n--- Actividad: ${activityType} ---\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 506
+BEFORE: content += `\${act.userMessaged.userMessage}\n`;
+AFTER: content += `${act.userMessaged.userMessage}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 508
+BEFORE: content += `\${act.agentMessaged.agentMessage}\n`;
+AFTER: content += `${act.agentMessaged.agentMessage}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 510
+BEFORE: if (act.progressUpdated.description) content += `\${act.progressUpdated.description}\n`;
+AFTER: if (act.progressUpdated.description) content += `${act.progressUpdated.description}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 513
+BEFORE: content += `PASOS:\n\${steps.map(s => `\${(s.index || 0) + 1}. \${s.title}: \${s.description || ''}`).join('\n')}\n`;
+AFTER: content += `PASOS:\n${steps.map(s => `${(s.index || 0) + 1}. ${s.title}: ${s.description || ''}`).join('\n')}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 515
+BEFORE: content += `Commit: \${act.sessionCompleted.commitMessage || '---'}\n`;
+AFTER: content += `Commit: ${act.sessionCompleted.commitMessage || '---'}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 517
+BEFORE: content += `Razón: \${act.sessionFailed.reason || 'Desconocida'}\n`;
+AFTER: content += `Razón: ${act.sessionFailed.reason || 'Desconocida'}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 523
+BEFORE: content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n\${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+AFTER: content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 526
+BEFORE: content += `\nCOMANDO: \${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n\${art.bashOutput.output}\n\`\`\`\n`;
+AFTER: content += `\nCOMANDO: ${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n${art.bashOutput.output}\n\`\`\`\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 560
+BEFORE: input.value = `Respecto al paso \${stepIndex} (\${stepTitle}): ` + input.value;
+AFTER: input.value = `Respecto al paso ${stepIndex} (${stepTitle}): ` + input.value;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 16
+BEFORE: if($("m-success-rate")) $("m-success-rate").textContent = `\${successRate}%`;
+AFTER: if($("m-success-rate")) $("m-success-rate").textContent = `${successRate}%`;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 17
+BEFORE: if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `\${Math.round(totalTokens/1000)}k` : totalTokens;
+AFTER: if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `${Math.round(totalTokens/1000)}k` : totalTokens;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 26
+BEFORE: if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `\${doneP} 100`);
+AFTER: if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `${doneP} 100`);
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 28
+BEFORE: $("donut-error").setAttribute("stroke-dasharray", `\${errorP} 100`);
+AFTER: $("donut-error").setAttribute("stroke-dasharray", `${errorP} 100`);
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 29
+BEFORE: $("donut-error").setAttribute("stroke-dashoffset", `-\${doneP}`);
+AFTER: $("donut-error").setAttribute("stroke-dashoffset", `-${doneP}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 76
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 81
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 87
+BEFORE: const col = $(`col-\${targetColId}`);
+AFTER: const col = $(`col-${targetColId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 187
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${branch}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${branch}`;
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 330
+BEFORE: const colEl = $(`kb-\${colId}`), countEl = $(`kb-count-\${colId}`), mCountEl = $(`m-count-\${colId}`);
+AFTER: const colEl = $(`kb-${colId}`), countEl = $(`kb-count-${colId}`), mCountEl = $(`m-count-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 352
+BEFORE: <div class="kb-card \${colId} \${isArchived ? 'archived' : ''}"
+AFTER: <div class="kb-card ${colId} ${isArchived ? 'archived' : ''}"
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 353
+BEFORE: \${canDrag ? `draggable="true" ondragstart="onDragStart(event, '\${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+AFTER: ${canDrag ? `draggable="true" ondragstart="onDragStart(event, '${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 354
+BEFORE: onclick="openDrawer('\${s.name}')">
+AFTER: onclick="openDrawer('${s.name}')">
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 356
+BEFORE: <div class="kb-card-id">#\${sid}\${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+AFTER: <div class="kb-card-id">#${sid}${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 357
+BEFORE: <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${s.state}</span>
+AFTER: <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${s.state}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 359
+BEFORE: <div class="kb-card-task">\${escapeHtml(s.title || s.prompt)}</div>
+AFTER: <div class="kb-card-task">${escapeHtml(s.title || s.prompt)}</div>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 361
+BEFORE: <span class="kb-card-repo">\${repo}</span>
+AFTER: <span class="kb-card-repo">${repo}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 362
+BEFORE: <span class="kb-card-time">\${getTimeAgo(s.createTime)}</span>
+AFTER: <span class="kb-card-time">${getTimeAgo(s.createTime)}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 365
+BEFORE: \${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('\${archiveId}')">Restaurar</button>` : ''}
+AFTER: ${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('${archiveId}')">Restaurar</button>` : ''}
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 366
+BEFORE: <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('\${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+AFTER: <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 367
+BEFORE: <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '\${sid}'); localStorage.setItem('hy_neural_session_id', '\${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+AFTER: <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '${sid}'); localStorage.setItem('hy_neural_session_id', '${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 379
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 11
+BEFORE: const panel = $(`panel-\${tabMap[tabId]}`);
+AFTER: const panel = $(`panel-${tabMap[tabId]}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 20
+BEFORE: const panel = $(`panel-\${tabMap[tabId]}`);
+AFTER: const panel = $(`panel-${tabMap[tabId]}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 31
+BEFORE: } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: \${e.message}</div>`; }
+AFTER: } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: ${e.message}</div>`; }
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 36
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 38
+BEFORE: $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${pr.title}</div><div style="font-size:11px; color:var(--text3);">#\${pr.number} por \${pr.user.login} • \${getTimeAgo(pr.updated_at)}</div></div><a href="\${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+AFTER: $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${pr.title}</div><div style="font-size:11px; color:var(--text3);">#${pr.number} por ${pr.user.login} • ${getTimeAgo(pr.updated_at)}</div></div><a href="${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 44
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 46
+BEFORE: $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${issue.title}</div><div style="font-size:11px; color:var(--text3);">#\${issue.number} • \${getTimeAgo(issue.created_at)}</div></div><a href="\${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+AFTER: $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${issue.title}</div><div style="font-size:11px; color:var(--text3);">#${issue.number} • ${getTimeAgo(issue.created_at)}</div></div><a href="${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 52
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 54
+BEFORE: $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">\${b.name}</span>\${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+AFTER: $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">${b.name}</span>${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 59
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 63
+BEFORE: return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:\${color}">●</span> \${run.name} #\${run.run_number}</div><div style="font-size:11px; color:var(--text3);">\${run.head_branch} • \${getTimeAgo(run.updated_at)}</div></div><a href="\${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+AFTER: return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:${color}">●</span> ${run.name} #${run.run_number}</div><div style="font-size:11px; color:var(--text3);">${run.head_branch} • ${getTimeAgo(run.updated_at)}</div></div><a href="${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 69
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 71
+BEFORE: $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">\${n.repository.name}</div><div style="font-weight:600; color:var(--text);">\${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+AFTER: $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">${n.repository.name}</div><div style="font-weight:600; color:var(--text);">${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 19
+BEFORE: localStorage.setItem(`hy_neural_context_\${sessionId}`, JSON.stringify(sessionData));
+AFTER: localStorage.setItem(`hy_neural_context_${sessionId}`, JSON.stringify(sessionData));
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 54
+BEFORE: const saved = localStorage.getItem(`hy_neural_context_\${sessionId}`);
+AFTER: const saved = localStorage.getItem(`hy_neural_context_${sessionId}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 82
+BEFORE: const analyzedKey = `v2_jules_analyzed_\${output.session_id}_\${output.status}`;
+AFTER: const analyzedKey = `v2_jules_analyzed_${output.session_id}_${output.status}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 86
+BEFORE: window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #\${output.session_id})...` });
+AFTER: window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #${output.session_id})...` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 91
+BEFORE: const prompt = `Jules ha completado una operación (Estado: \${output.status}).\n\nDETALLES:\n- Sesión: #\${output.session_id}\n- Tarea: \${output.title}\n- Repo: \${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+AFTER: const prompt = `Jules ha completado una operación (Estado: ${output.status}).\n\nDETALLES:\n- Sesión: #${output.session_id}\n- Tarea: ${output.title}\n- Repo: ${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 99
+BEFORE: window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n\${analysis}` });
+AFTER: window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n${analysis}` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 112
+BEFORE: status.textContent = `[\${tel.tag}] \${tel.msg}`;
+AFTER: status.textContent = `[${tel.tag}] ${tel.msg}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 125
+BEFORE: const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: \${t.blocks.join(', ')}` : 'No bloquea a nadie';
+AFTER: const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: ${t.blocks.join(', ')}` : 'No bloquea a nadie';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 126
+BEFORE: const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: \${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+AFTER: const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: ${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 129
+BEFORE: `ID: #\${t.id}\n` +
+AFTER: `ID: #${t.id}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 130
+BEFORE: `Título: \${t.titulo || t.title}\n` +
+AFTER: `Título: ${t.titulo || t.title}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 131
+BEFORE: `Descripción: \${t.descripcion || t.description}\n` +
+AFTER: `Descripción: ${t.descripcion || t.description}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 132
+BEFORE: `Criterios de Aceptación: \${t.acceptance_criteria || 'N/A'}\n` +
+AFTER: `Criterios de Aceptación: ${t.acceptance_criteria || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 133
+BEFORE: `Subtareas: \${JSON.stringify(t.subtasks || [])}\n` +
+AFTER: `Subtareas: ${JSON.stringify(t.subtasks || [])}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 134
+BEFORE: `Estado: \${t.estado || t.status}\n` +
+AFTER: `Estado: ${t.estado || t.status}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 135
+BEFORE: `Prioridad: \${t.prioridad || t.priority}\n` +
+AFTER: `Prioridad: ${t.prioridad || t.priority}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 136
+BEFORE: `Rama: \${t.rama || 'N/A'}\n` +
+AFTER: `Rama: ${t.rama || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 137
+BEFORE: `Milestone: \${t.milestone || 'N/A'}\n` +
+AFTER: `Milestone: ${t.milestone || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 138
+BEFORE: `Repositorio: \${t.repository || t.repo || 'N/A'}\n` +
+AFTER: `Repositorio: ${t.repository || t.repo || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 139
+BEFORE: `Dependencias: \${blockingInfo} | \${blockedByInfo}\n`;
+AFTER: `Dependencias: ${blockingInfo} | ${blockedByInfo}\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 147
+BEFORE: systemPrompt += `\n### Historial reciente de Jules (Sesión #\${linkedSid}):\n\${logs}\n`;
+AFTER: systemPrompt += `\n### Historial reciente de Jules (Sesión #${linkedSid}):\n${logs}\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 168
+BEFORE: const endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+AFTER: const endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 183
+BEFORE: if (!isOllama) headers["Authorization"] = `Bearer \${apiKey}`;
+AFTER: if (!isOllama) headers["Authorization"] = `Bearer ${apiKey}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 191
+BEFORE: if (!res.ok) throw new Error(`API Error: \${res.status}`);
+AFTER: if (!res.ok) throw new Error(`API Error: ${res.status}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 282
+BEFORE: thinking.textContent = retryCount > 0 ? `REINTENTANDO (\${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+AFTER: thinking.textContent = retryCount > 0 ? `REINTENTANDO (${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 299
+BEFORE: content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n\${m.content}` : m.content
+AFTER: content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n${m.content}` : m.content
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 304
+BEFORE: const contextPrefix = `[CONTEXTO TAREA #\${t.id}: \${t.titulo}]\n`;
+AFTER: const contextPrefix = `[CONTEXTO TAREA #${t.id}: ${t.titulo}]\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 321
+BEFORE: let endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+AFTER: let endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 330
+BEFORE: 'Authorization': `Bearer \${apiKey}`
+AFTER: 'Authorization': `Bearer ${apiKey}`
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 360
+BEFORE: throw new Error(errData.error?.message || `HTTP \${res.status}`);
+AFTER: throw new Error(errData.error?.message || `HTTP ${res.status}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 368
+BEFORE: addTel("SYSTEM", `Reintentando comunicación (\${retryCount + 1}/2)...`, "warn");
+AFTER: addTel("SYSTEM", `Reintentando comunicación (${retryCount + 1}/2)...`, "warn");
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 372
+BEFORE: window.chatV2Messages.push({ role: 'system', content: `❌ Error: \${e.message}` });
+AFTER: window.chatV2Messages.push({ role: 'system', content: `❌ Error: ${e.message}` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 429
+BEFORE: finalHtml += `<div class="thinking-block">\${escapeHtml(thinkingContent)}</div>`;
+AFTER: finalHtml += `<div class="thinking-block">${escapeHtml(thinkingContent)}</div>`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 495
+BEFORE: return `<div class="message-system">\${m.content}</div>`;
+AFTER: return `<div class="message-system">${m.content}</div>`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 517
+BEFORE: <div class="\${roleClass}">
+AFTER: <div class="${roleClass}">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 518
+BEFORE: <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: \${labelColor}">
+AFTER: <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: ${labelColor}">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 519
+BEFORE: \${label}
+AFTER: ${label}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 522
+BEFORE: \${m.thinking ? `<div class="thinking-block">\${escapeHtml(m.thinking)}</div>` : ''}
+AFTER: ${m.thinking ? `<div class="thinking-block">${escapeHtml(m.thinking)}</div>` : ''}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 523
+BEFORE: \${marked.parse(m.content)}
+AFTER: ${marked.parse(m.content)}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 551
+BEFORE: \${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+AFTER: ${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 554
+BEFORE: <div id="drawer-name-display-\${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('\${s.id}')">
+AFTER: <div id="drawer-name-display-${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('${s.id}')">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 555
+BEFORE: \${s.name}
+AFTER: ${s.name}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 557
+BEFORE: <input id="drawer-name-edit-\${s.id}" type="text" class="cfg-input hidden" value="\${s.name}" onblur="saveRenameFromDrawer('\${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+AFTER: <input id="drawer-name-edit-${s.id}" type="text" class="cfg-input hidden" value="${s.name}" onblur="saveRenameFromDrawer('${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 559
+BEFORE: <span style="font-size: 9px; color: \${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+AFTER: <span style="font-size: 9px; color: ${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 560
+BEFORE: \${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} \${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+AFTER: ${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} ${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 562
+BEFORE: <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#\${s.id}</span>
+AFTER: <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#${s.id}</span>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 566
+BEFORE: <button onclick="renameFromDrawer('\${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+AFTER: <button onclick="renameFromDrawer('${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 567
+BEFORE: <button onclick="archiveFromDrawer('\${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); \${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+AFTER: <button onclick="archiveFromDrawer('${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); ${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 568
+BEFORE: <button onclick="deleteFromDrawer('\${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+AFTER: <button onclick="deleteFromDrawer('${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 573
+BEFORE: <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> \${s.task_title}
+AFTER: <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> ${s.task_title}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 575
+BEFORE: <span style="color: var(--text3);">\${new Date(s.start).toLocaleDateString()}</span>
+AFTER: <span style="color: var(--text3);">${new Date(s.start).toLocaleDateString()}</span>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 582
+BEFORE: $(`drawer-name-display-\${sid}`).classList.add('hidden');
+AFTER: $(`drawer-name-display-${sid}`).classList.add('hidden');
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 583
+BEFORE: const edit = $(`drawer-name-edit-\${sid}`);
+AFTER: const edit = $(`drawer-name-edit-${sid}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 589
+BEFORE: const edit = $(`drawer-name-edit-\${sid}`);
+AFTER: const edit = $(`drawer-name-edit-${sid}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 637
+BEFORE: localStorage.setItem(`hy_neural_session_id_\${claudeId}`, s.id);
+AFTER: localStorage.setItem(`hy_neural_session_id_${claudeId}`, s.id);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 30
+BEFORE: addTel("SYSTEM", `Iniciado como \${user.login}`, "success");
+AFTER: addTel("SYSTEM", `Iniciado como ${user.login}`, "success");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 81
+BEFORE: if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+AFTER: if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 83
+BEFORE: formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+AFTER: formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 86
+BEFORE: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+AFTER: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 92
+BEFORE: formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #\${task.id} - \${task.titulo || task.title}\n`;
+AFTER: formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #${task.id} - ${task.titulo || task.title}\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 93
+BEFORE: if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: \${task.descripcion}\n`;
+AFTER: if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: ${task.descripcion}\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 102
+BEFORE: src.name === targetRepo || src.name === `sources/github/\${targetRepo}` || src.displayName === targetRepo
+AFTER: src.name === targetRepo || src.name === `sources/github/${targetRepo}` || src.displayName === targetRepo
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 107
+BEFORE: const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/\${targetRepo}`;
+AFTER: const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/${targetRepo}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 126
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${targetBranch}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${targetBranch}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 128
+BEFORE: addTel("SYSTEM", `Rama auto-ajustada a \${targetBranch} (Tarea #\${task.id})`, "info");
+AFTER: addTel("SYSTEM", `Rama auto-ajustada a ${targetBranch} (Tarea #${task.id})`, "info");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 146
+BEFORE: formattedPrompt = `Crea la branch \${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+AFTER: formattedPrompt = `Crea la branch ${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 186
+BEFORE: $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+AFTER: $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 253
+BEFORE: $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+AFTER: $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 273
+BEFORE: formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+AFTER: formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 277
+BEFORE: formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+AFTER: formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 281
+BEFORE: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+AFTER: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 337
+BEFORE: const avatarUrl = user.avatar_url || `https://github.com/\${user.login}.png`;
+AFTER: const avatarUrl = user.avatar_url || `https://github.com/${user.login}.png`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 340
+BEFORE: $('sb-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('sb-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 348
+BEFORE: $('mob-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('mob-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 353
+BEFORE: $('hdr-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('hdr-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 383
+BEFORE: localStorage.removeItem(`hy_neural_session_id_\${claudeId}`);
+AFTER: localStorage.removeItem(`hy_neural_session_id_${claudeId}`);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 403
+BEFORE: addTel("SYSTEM", `Iniciando sesión - Source: "\${source}", Branch: "\${branch}"`, "info");
+AFTER: addTel("SYSTEM", `Iniciando sesión - Source: "${source}", Branch: "${branch}"`, "info");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 420
+BEFORE: prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-\${Date.now()}).`;
+AFTER: prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-${Date.now()}).`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 443
+BEFORE: addTel("JULES", `Sesión iniciada: \${sid}`, "success");
+AFTER: addTel("JULES", `Sesión iniciada: ${sid}`, "success");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 447
+BEFORE: localStorage.setItem(`hy_neural_session_id_\${claudeId}`, sid);
+AFTER: localStorage.setItem(`hy_neural_session_id_${claudeId}`, sid);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 453
+BEFORE: const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural \${new Date().toLocaleDateString()}`;
+AFTER: const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural ${new Date().toLocaleDateString()}`;
+---

--- a/audit_part_aa
+++ b/audit_part_aa
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 74
+BEFORE: el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">\${s.displayName || s.name.split('/').pop()}</span>\${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+AFTER: el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">${s.displayName || s.name.split('/').pop()}</span>${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 88
+BEFORE: if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → \${sourceName.split('/').pop()}`, "info");
+AFTER: if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → ${sourceName.split('/').pop()}`, "info");
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 89
+BEFORE: else addTel("SYSTEM", `Contexto: \${sourceName.split('/').pop()}`, "info");
+AFTER: else addTel("SYSTEM", `Contexto: ${sourceName.split('/').pop()}`, "info");
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 100
+BEFORE: if(sessCtx) sessCtx.textContent = `\${displayLabel}: cargando...`;
+AFTER: if(sessCtx) sessCtx.textContent = `${displayLabel}: cargando...`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 110
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${e.target.value}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${e.target.value}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 118
+BEFORE: branchSelect.innerHTML = branches.map(b => `<option value="\${b.name}" \${b.name === defaultBranch ? 'selected' : ''}>\${b.name}\${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+AFTER: branchSelect.innerHTML = branches.map(b => `<option value="${b.name}" ${b.name === defaultBranch ? 'selected' : ''}>${b.name}${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 121
+BEFORE: if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>\${branches.length} ramas</span>`;
+AFTER: if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>${branches.length} ramas</span>`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 123
+BEFORE: if(sessCtx) sessCtx.textContent = `\${displayLabel}: \${activeBranch}`;
+AFTER: if(sessCtx) sessCtx.textContent = `${displayLabel}: ${activeBranch}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 138
+BEFORE: item.className = `custom-dropdown-item \${!isInstalled ? 'disabled' : ''}`;
+AFTER: item.className = `custom-dropdown-item ${!isInstalled ? 'disabled' : ''}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 144
+BEFORE: item.innerHTML = `<span>\${s.displayName || s.name.split('/').pop()}</span> \${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+AFTER: item.innerHTML = `<span>${s.displayName || s.name.split('/').pop()}</span> ${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 18
+BEFORE: return `<span class="session-badge session-badge--\${cfg.cls}">
+AFTER: return `<span class="session-badge session-badge--${cfg.cls}">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 19
+BEFORE: \${cfg.icon} \${cfg.label}
+AFTER: ${cfg.icon} ${cfg.label}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 38
+BEFORE: const stickyBadge = document.getElementById(`sticky-badge-\${idSafe}`);
+AFTER: const stickyBadge = document.getElementById(`sticky-badge-${idSafe}`);
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 138
+BEFORE: return `<div class="\${cls}">\${escapeHtml(line)}</div>`;
+AFTER: return `<div class="${cls}">${escapeHtml(line)}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 145
+BEFORE: +\${hiddenCount} líneas más —
+AFTER: +${hiddenCount} líneas más —
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 146
+BEFORE: <a href="\${session?.url || '#'}" target="_blank"
+AFTER: <a href="${session?.url || '#'}" target="_blank"
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 160
+BEFORE: \${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+AFTER: ${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 161
+BEFORE: — \${escapeHtml(msg)}</span>` : ''}
+AFTER: — ${escapeHtml(msg)}</span>` : ''}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 165
+BEFORE: \${diffLinesHtml}
+AFTER: ${diffLinesHtml}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 166
+BEFORE: \${moreHtml}
+AFTER: ${moreHtml}
+---

--- a/audit_part_ab
+++ b/audit_part_ab
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 181
+BEFORE: \${(s.index || 0) + 1}.
+AFTER: ${(s.index || 0) + 1}.
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 185
+BEFORE: \${s.title || 'Sin título'}
+AFTER: ${s.title || 'Sin título'}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 187
+BEFORE: \${s.description ? `
+AFTER: ${s.description ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 189
+BEFORE: \${s.description}
+AFTER: ${s.description}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 192
+BEFORE: <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('\${activity.name?.split('/activities/')[0]}', \${(s.index || 0) + 1}, '\${escapeHtml(s.title)}')">
+AFTER: <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('${activity.name?.split('/activities/')[0]}', ${(s.index || 0) + 1}, '${escapeHtml(s.title)}')">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 203
+BEFORE: 📋 Plan generado (\${steps.length} pasos)
+AFTER: 📋 Plan generado (${steps.length} pasos)
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 205
+BEFORE: <div>\${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+AFTER: <div>${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 216
+BEFORE: html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+AFTER: html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 221
+BEFORE: html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+AFTER: html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 235
+BEFORE: \${parsedTitle}
+AFTER: ${parsedTitle}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 236
+BEFORE: \${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">\${parsedDesc}</div>` : ''}
+AFTER: ${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">${parsedDesc}</div>` : ''}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 238
+BEFORE: \${bash ? `
+AFTER: ${bash ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 241
+BEFORE: $ \${escapeHtml(bash.command || '')}
+AFTER: $ ${escapeHtml(bash.command || '')}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 242
+BEFORE: <span style="color:\${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+AFTER: <span style="color:${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 243
+BEFORE: [exit \${bash.exitCode ?? '?'}]
+AFTER: [exit ${bash.exitCode ?? '?'}]
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 246
+BEFORE: <pre class="activity-code">\${escapeHtml(bash.output || "")}</pre>
+AFTER: <pre class="activity-code">${escapeHtml(bash.output || "")}</pre>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 260
+BEFORE: \${parsed ? `
+AFTER: ${parsed ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 264
+BEFORE: \${parsed}
+AFTER: ${parsed}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 272
+BEFORE: ❌ Sesión fallida: \${escapeHtml(reason)}
+AFTER: ❌ Sesión fallida: ${escapeHtml(reason)}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 282
+BEFORE: \${escapeHtml(desc)}
+AFTER: ${escapeHtml(desc)}
+---

--- a/audit_part_ac
+++ b/audit_part_ac
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 313
+BEFORE: <button onclick="approveJulesPlan('\${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+AFTER: <button onclick="approveJulesPlan('${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 425
+BEFORE: return `<tr onclick="openDrawer('\${s.name}')"><td><span class="sid">\${s.name.split('/').pop()}</span></td><td class="tdesc">\${escapeHtml(s.title || s.prompt)}</td><td class="tmono">\${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">\${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>\${statusLabel}</span></td><td class="tmono">\${getTimeAgo(s.createTime)}</td><td class="tmono">\${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+AFTER: return `<tr onclick="openDrawer('${s.name}')"><td><span class="sid">${s.name.split('/').pop()}</span></td><td class="tdesc">${escapeHtml(s.title || s.prompt)}</td><td class="tmono">${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>${statusLabel}</span></td><td class="tmono">${getTimeAgo(s.createTime)}</td><td class="tmono">${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 434
+BEFORE: <div onclick="openDrawer('\${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+AFTER: <div onclick="openDrawer('${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 436
+BEFORE: <span class="sid">\${s.name.split('/').pop()}</span>
+AFTER: <span class="sid">${s.name.split('/').pop()}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 437
+BEFORE: <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${statusLabel}</span>
+AFTER: <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${statusLabel}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 439
+BEFORE: <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">\${escapeHtml(s.title || s.prompt)}</div>
+AFTER: <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">${escapeHtml(s.title || s.prompt)}</div>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 441
+BEFORE: <span>\${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+AFTER: <span>${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 442
+BEFORE: <span>\${getTimeAgo(s.createTime)}</span>
+AFTER: <span>${getTimeAgo(s.createTime)}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 496
+BEFORE: else if (act.progressUpdated) activityType = `Progreso: \${act.progressUpdated.title}`;
+AFTER: else if (act.progressUpdated) activityType = `Progreso: ${act.progressUpdated.title}`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 502
+BEFORE: const separator = `\n--- Actividad: \${activityType} ---\n`;
+AFTER: const separator = `\n--- Actividad: ${activityType} ---\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 506
+BEFORE: content += `\${act.userMessaged.userMessage}\n`;
+AFTER: content += `${act.userMessaged.userMessage}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 508
+BEFORE: content += `\${act.agentMessaged.agentMessage}\n`;
+AFTER: content += `${act.agentMessaged.agentMessage}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 510
+BEFORE: if (act.progressUpdated.description) content += `\${act.progressUpdated.description}\n`;
+AFTER: if (act.progressUpdated.description) content += `${act.progressUpdated.description}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 513
+BEFORE: content += `PASOS:\n\${steps.map(s => `\${(s.index || 0) + 1}. \${s.title}: \${s.description || ''}`).join('\n')}\n`;
+AFTER: content += `PASOS:\n${steps.map(s => `${(s.index || 0) + 1}. ${s.title}: ${s.description || ''}`).join('\n')}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 515
+BEFORE: content += `Commit: \${act.sessionCompleted.commitMessage || '---'}\n`;
+AFTER: content += `Commit: ${act.sessionCompleted.commitMessage || '---'}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 517
+BEFORE: content += `Razón: \${act.sessionFailed.reason || 'Desconocida'}\n`;
+AFTER: content += `Razón: ${act.sessionFailed.reason || 'Desconocida'}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 523
+BEFORE: content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n\${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+AFTER: content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 526
+BEFORE: content += `\nCOMANDO: \${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n\${art.bashOutput.output}\n\`\`\`\n`;
+AFTER: content += `\nCOMANDO: ${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n${art.bashOutput.output}\n\`\`\`\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 560
+BEFORE: input.value = `Respecto al paso \${stepIndex} (\${stepTitle}): ` + input.value;
+AFTER: input.value = `Respecto al paso ${stepIndex} (${stepTitle}): ` + input.value;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 16
+BEFORE: if($("m-success-rate")) $("m-success-rate").textContent = `\${successRate}%`;
+AFTER: if($("m-success-rate")) $("m-success-rate").textContent = `${successRate}%`;
+---

--- a/audit_part_ad
+++ b/audit_part_ad
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 17
+BEFORE: if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `\${Math.round(totalTokens/1000)}k` : totalTokens;
+AFTER: if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `${Math.round(totalTokens/1000)}k` : totalTokens;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 26
+BEFORE: if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `\${doneP} 100`);
+AFTER: if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `${doneP} 100`);
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 28
+BEFORE: $("donut-error").setAttribute("stroke-dasharray", `\${errorP} 100`);
+AFTER: $("donut-error").setAttribute("stroke-dasharray", `${errorP} 100`);
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 29
+BEFORE: $("donut-error").setAttribute("stroke-dashoffset", `-\${doneP}`);
+AFTER: $("donut-error").setAttribute("stroke-dashoffset", `-${doneP}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 76
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 81
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 87
+BEFORE: const col = $(`col-\${targetColId}`);
+AFTER: const col = $(`col-${targetColId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 187
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${branch}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${branch}`;
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 330
+BEFORE: const colEl = $(`kb-\${colId}`), countEl = $(`kb-count-\${colId}`), mCountEl = $(`m-count-\${colId}`);
+AFTER: const colEl = $(`kb-${colId}`), countEl = $(`kb-count-${colId}`), mCountEl = $(`m-count-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 352
+BEFORE: <div class="kb-card \${colId} \${isArchived ? 'archived' : ''}"
+AFTER: <div class="kb-card ${colId} ${isArchived ? 'archived' : ''}"
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 353
+BEFORE: \${canDrag ? `draggable="true" ondragstart="onDragStart(event, '\${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+AFTER: ${canDrag ? `draggable="true" ondragstart="onDragStart(event, '${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 354
+BEFORE: onclick="openDrawer('\${s.name}')">
+AFTER: onclick="openDrawer('${s.name}')">
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 356
+BEFORE: <div class="kb-card-id">#\${sid}\${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+AFTER: <div class="kb-card-id">#${sid}${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 357
+BEFORE: <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${s.state}</span>
+AFTER: <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${s.state}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 359
+BEFORE: <div class="kb-card-task">\${escapeHtml(s.title || s.prompt)}</div>
+AFTER: <div class="kb-card-task">${escapeHtml(s.title || s.prompt)}</div>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 361
+BEFORE: <span class="kb-card-repo">\${repo}</span>
+AFTER: <span class="kb-card-repo">${repo}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 362
+BEFORE: <span class="kb-card-time">\${getTimeAgo(s.createTime)}</span>
+AFTER: <span class="kb-card-time">${getTimeAgo(s.createTime)}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 365
+BEFORE: \${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('\${archiveId}')">Restaurar</button>` : ''}
+AFTER: ${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('${archiveId}')">Restaurar</button>` : ''}
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 366
+BEFORE: <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('\${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+AFTER: <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 367
+BEFORE: <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '\${sid}'); localStorage.setItem('hy_neural_session_id', '\${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+AFTER: <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '${sid}'); localStorage.setItem('hy_neural_session_id', '${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+---

--- a/audit_part_ae
+++ b/audit_part_ae
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 379
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 11
+BEFORE: const panel = $(`panel-\${tabMap[tabId]}`);
+AFTER: const panel = $(`panel-${tabMap[tabId]}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 20
+BEFORE: const panel = $(`panel-\${tabMap[tabId]}`);
+AFTER: const panel = $(`panel-${tabMap[tabId]}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 31
+BEFORE: } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: \${e.message}</div>`; }
+AFTER: } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: ${e.message}</div>`; }
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 36
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 38
+BEFORE: $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${pr.title}</div><div style="font-size:11px; color:var(--text3);">#\${pr.number} por \${pr.user.login} • \${getTimeAgo(pr.updated_at)}</div></div><a href="\${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+AFTER: $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${pr.title}</div><div style="font-size:11px; color:var(--text3);">#${pr.number} por ${pr.user.login} • ${getTimeAgo(pr.updated_at)}</div></div><a href="${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 44
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 46
+BEFORE: $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${issue.title}</div><div style="font-size:11px; color:var(--text3);">#\${issue.number} • \${getTimeAgo(issue.created_at)}</div></div><a href="\${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+AFTER: $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${issue.title}</div><div style="font-size:11px; color:var(--text3);">#${issue.number} • ${getTimeAgo(issue.created_at)}</div></div><a href="${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 52
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 54
+BEFORE: $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">\${b.name}</span>\${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+AFTER: $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">${b.name}</span>${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 59
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 63
+BEFORE: return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:\${color}">●</span> \${run.name} #\${run.run_number}</div><div style="font-size:11px; color:var(--text3);">\${run.head_branch} • \${getTimeAgo(run.updated_at)}</div></div><a href="\${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+AFTER: return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:${color}">●</span> ${run.name} #${run.run_number}</div><div style="font-size:11px; color:var(--text3);">${run.head_branch} • ${getTimeAgo(run.updated_at)}</div></div><a href="${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 69
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 71
+BEFORE: $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">\${n.repository.name}</div><div style="font-weight:600; color:var(--text);">\${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+AFTER: $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">${n.repository.name}</div><div style="font-weight:600; color:var(--text);">${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 19
+BEFORE: localStorage.setItem(`hy_neural_context_\${sessionId}`, JSON.stringify(sessionData));
+AFTER: localStorage.setItem(`hy_neural_context_${sessionId}`, JSON.stringify(sessionData));
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 54
+BEFORE: const saved = localStorage.getItem(`hy_neural_context_\${sessionId}`);
+AFTER: const saved = localStorage.getItem(`hy_neural_context_${sessionId}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 82
+BEFORE: const analyzedKey = `v2_jules_analyzed_\${output.session_id}_\${output.status}`;
+AFTER: const analyzedKey = `v2_jules_analyzed_${output.session_id}_${output.status}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 86
+BEFORE: window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #\${output.session_id})...` });
+AFTER: window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #${output.session_id})...` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 91
+BEFORE: const prompt = `Jules ha completado una operación (Estado: \${output.status}).\n\nDETALLES:\n- Sesión: #\${output.session_id}\n- Tarea: \${output.title}\n- Repo: \${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+AFTER: const prompt = `Jules ha completado una operación (Estado: ${output.status}).\n\nDETALLES:\n- Sesión: #${output.session_id}\n- Tarea: ${output.title}\n- Repo: ${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 99
+BEFORE: window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n\${analysis}` });
+AFTER: window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n${analysis}` });
+---

--- a/audit_part_af
+++ b/audit_part_af
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 112
+BEFORE: status.textContent = `[\${tel.tag}] \${tel.msg}`;
+AFTER: status.textContent = `[${tel.tag}] ${tel.msg}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 125
+BEFORE: const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: \${t.blocks.join(', ')}` : 'No bloquea a nadie';
+AFTER: const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: ${t.blocks.join(', ')}` : 'No bloquea a nadie';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 126
+BEFORE: const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: \${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+AFTER: const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: ${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 129
+BEFORE: `ID: #\${t.id}\n` +
+AFTER: `ID: #${t.id}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 130
+BEFORE: `Título: \${t.titulo || t.title}\n` +
+AFTER: `Título: ${t.titulo || t.title}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 131
+BEFORE: `Descripción: \${t.descripcion || t.description}\n` +
+AFTER: `Descripción: ${t.descripcion || t.description}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 132
+BEFORE: `Criterios de Aceptación: \${t.acceptance_criteria || 'N/A'}\n` +
+AFTER: `Criterios de Aceptación: ${t.acceptance_criteria || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 133
+BEFORE: `Subtareas: \${JSON.stringify(t.subtasks || [])}\n` +
+AFTER: `Subtareas: ${JSON.stringify(t.subtasks || [])}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 134
+BEFORE: `Estado: \${t.estado || t.status}\n` +
+AFTER: `Estado: ${t.estado || t.status}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 135
+BEFORE: `Prioridad: \${t.prioridad || t.priority}\n` +
+AFTER: `Prioridad: ${t.prioridad || t.priority}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 136
+BEFORE: `Rama: \${t.rama || 'N/A'}\n` +
+AFTER: `Rama: ${t.rama || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 137
+BEFORE: `Milestone: \${t.milestone || 'N/A'}\n` +
+AFTER: `Milestone: ${t.milestone || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 138
+BEFORE: `Repositorio: \${t.repository || t.repo || 'N/A'}\n` +
+AFTER: `Repositorio: ${t.repository || t.repo || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 139
+BEFORE: `Dependencias: \${blockingInfo} | \${blockedByInfo}\n`;
+AFTER: `Dependencias: ${blockingInfo} | ${blockedByInfo}\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 147
+BEFORE: systemPrompt += `\n### Historial reciente de Jules (Sesión #\${linkedSid}):\n\${logs}\n`;
+AFTER: systemPrompt += `\n### Historial reciente de Jules (Sesión #${linkedSid}):\n${logs}\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 168
+BEFORE: const endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+AFTER: const endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 183
+BEFORE: if (!isOllama) headers["Authorization"] = `Bearer \${apiKey}`;
+AFTER: if (!isOllama) headers["Authorization"] = `Bearer ${apiKey}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 191
+BEFORE: if (!res.ok) throw new Error(`API Error: \${res.status}`);
+AFTER: if (!res.ok) throw new Error(`API Error: ${res.status}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 282
+BEFORE: thinking.textContent = retryCount > 0 ? `REINTENTANDO (\${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+AFTER: thinking.textContent = retryCount > 0 ? `REINTENTANDO (${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 299
+BEFORE: content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n\${m.content}` : m.content
+AFTER: content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n${m.content}` : m.content
+---

--- a/audit_part_ag
+++ b/audit_part_ag
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 304
+BEFORE: const contextPrefix = `[CONTEXTO TAREA #\${t.id}: \${t.titulo}]\n`;
+AFTER: const contextPrefix = `[CONTEXTO TAREA #${t.id}: ${t.titulo}]\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 321
+BEFORE: let endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+AFTER: let endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 330
+BEFORE: 'Authorization': `Bearer \${apiKey}`
+AFTER: 'Authorization': `Bearer ${apiKey}`
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 360
+BEFORE: throw new Error(errData.error?.message || `HTTP \${res.status}`);
+AFTER: throw new Error(errData.error?.message || `HTTP ${res.status}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 368
+BEFORE: addTel("SYSTEM", `Reintentando comunicación (\${retryCount + 1}/2)...`, "warn");
+AFTER: addTel("SYSTEM", `Reintentando comunicación (${retryCount + 1}/2)...`, "warn");
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 372
+BEFORE: window.chatV2Messages.push({ role: 'system', content: `❌ Error: \${e.message}` });
+AFTER: window.chatV2Messages.push({ role: 'system', content: `❌ Error: ${e.message}` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 429
+BEFORE: finalHtml += `<div class="thinking-block">\${escapeHtml(thinkingContent)}</div>`;
+AFTER: finalHtml += `<div class="thinking-block">${escapeHtml(thinkingContent)}</div>`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 495
+BEFORE: return `<div class="message-system">\${m.content}</div>`;
+AFTER: return `<div class="message-system">${m.content}</div>`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 517
+BEFORE: <div class="\${roleClass}">
+AFTER: <div class="${roleClass}">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 518
+BEFORE: <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: \${labelColor}">
+AFTER: <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: ${labelColor}">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 519
+BEFORE: \${label}
+AFTER: ${label}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 522
+BEFORE: \${m.thinking ? `<div class="thinking-block">\${escapeHtml(m.thinking)}</div>` : ''}
+AFTER: ${m.thinking ? `<div class="thinking-block">${escapeHtml(m.thinking)}</div>` : ''}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 523
+BEFORE: \${marked.parse(m.content)}
+AFTER: ${marked.parse(m.content)}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 551
+BEFORE: \${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+AFTER: ${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 554
+BEFORE: <div id="drawer-name-display-\${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('\${s.id}')">
+AFTER: <div id="drawer-name-display-${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('${s.id}')">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 555
+BEFORE: \${s.name}
+AFTER: ${s.name}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 557
+BEFORE: <input id="drawer-name-edit-\${s.id}" type="text" class="cfg-input hidden" value="\${s.name}" onblur="saveRenameFromDrawer('\${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+AFTER: <input id="drawer-name-edit-${s.id}" type="text" class="cfg-input hidden" value="${s.name}" onblur="saveRenameFromDrawer('${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 559
+BEFORE: <span style="font-size: 9px; color: \${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+AFTER: <span style="font-size: 9px; color: ${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 560
+BEFORE: \${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} \${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+AFTER: ${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} ${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 562
+BEFORE: <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#\${s.id}</span>
+AFTER: <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#${s.id}</span>
+---

--- a/audit_part_ah
+++ b/audit_part_ah
@@ -1,0 +1,100 @@
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 566
+BEFORE: <button onclick="renameFromDrawer('\${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+AFTER: <button onclick="renameFromDrawer('${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 567
+BEFORE: <button onclick="archiveFromDrawer('\${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); \${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+AFTER: <button onclick="archiveFromDrawer('${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); ${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 568
+BEFORE: <button onclick="deleteFromDrawer('\${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+AFTER: <button onclick="deleteFromDrawer('${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 573
+BEFORE: <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> \${s.task_title}
+AFTER: <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> ${s.task_title}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 575
+BEFORE: <span style="color: var(--text3);">\${new Date(s.start).toLocaleDateString()}</span>
+AFTER: <span style="color: var(--text3);">${new Date(s.start).toLocaleDateString()}</span>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 582
+BEFORE: $(`drawer-name-display-\${sid}`).classList.add('hidden');
+AFTER: $(`drawer-name-display-${sid}`).classList.add('hidden');
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 583
+BEFORE: const edit = $(`drawer-name-edit-\${sid}`);
+AFTER: const edit = $(`drawer-name-edit-${sid}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 589
+BEFORE: const edit = $(`drawer-name-edit-\${sid}`);
+AFTER: const edit = $(`drawer-name-edit-${sid}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 637
+BEFORE: localStorage.setItem(`hy_neural_session_id_\${claudeId}`, s.id);
+AFTER: localStorage.setItem(`hy_neural_session_id_${claudeId}`, s.id);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 30
+BEFORE: addTel("SYSTEM", `Iniciado como \${user.login}`, "success");
+AFTER: addTel("SYSTEM", `Iniciado como ${user.login}`, "success");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 81
+BEFORE: if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+AFTER: if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 83
+BEFORE: formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+AFTER: formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 86
+BEFORE: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+AFTER: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 92
+BEFORE: formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #\${task.id} - \${task.titulo || task.title}\n`;
+AFTER: formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #${task.id} - ${task.titulo || task.title}\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 93
+BEFORE: if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: \${task.descripcion}\n`;
+AFTER: if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: ${task.descripcion}\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 102
+BEFORE: src.name === targetRepo || src.name === `sources/github/\${targetRepo}` || src.displayName === targetRepo
+AFTER: src.name === targetRepo || src.name === `sources/github/${targetRepo}` || src.displayName === targetRepo
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 107
+BEFORE: const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/\${targetRepo}`;
+AFTER: const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/${targetRepo}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 126
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${targetBranch}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${targetBranch}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 128
+BEFORE: addTel("SYSTEM", `Rama auto-ajustada a \${targetBranch} (Tarea #\${task.id})`, "info");
+AFTER: addTel("SYSTEM", `Rama auto-ajustada a ${targetBranch} (Tarea #${task.id})`, "info");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 146
+BEFORE: formattedPrompt = `Crea la branch \${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+AFTER: formattedPrompt = `Crea la branch ${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+---

--- a/audit_part_ai
+++ b/audit_part_ai
@@ -1,0 +1,75 @@
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 186
+BEFORE: $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+AFTER: $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 253
+BEFORE: $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+AFTER: $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 273
+BEFORE: formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+AFTER: formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 277
+BEFORE: formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+AFTER: formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 281
+BEFORE: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+AFTER: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 337
+BEFORE: const avatarUrl = user.avatar_url || `https://github.com/\${user.login}.png`;
+AFTER: const avatarUrl = user.avatar_url || `https://github.com/${user.login}.png`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 340
+BEFORE: $('sb-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('sb-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 348
+BEFORE: $('mob-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('mob-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 353
+BEFORE: $('hdr-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('hdr-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 383
+BEFORE: localStorage.removeItem(`hy_neural_session_id_\${claudeId}`);
+AFTER: localStorage.removeItem(`hy_neural_session_id_${claudeId}`);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 403
+BEFORE: addTel("SYSTEM", `Iniciando sesión - Source: "\${source}", Branch: "\${branch}"`, "info");
+AFTER: addTel("SYSTEM", `Iniciando sesión - Source: "${source}", Branch: "${branch}"`, "info");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 420
+BEFORE: prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-\${Date.now()}).`;
+AFTER: prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-${Date.now()}).`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 443
+BEFORE: addTel("JULES", `Sesión iniciada: \${sid}`, "success");
+AFTER: addTel("JULES", `Sesión iniciada: ${sid}`, "success");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 447
+BEFORE: localStorage.setItem(`hy_neural_session_id_\${claudeId}`, sid);
+AFTER: localStorage.setItem(`hy_neural_session_id_${claudeId}`, sid);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 453
+BEFORE: const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural \${new Date().toLocaleDateString()}`;
+AFTER: const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural ${new Date().toLocaleDateString()}`;
+---

--- a/audit_report.py
+++ b/audit_report.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+files = [
+    "assets/javascript/repo-admin-api.js",
+    "assets/javascript/repo-admin-ui.js",
+    "assets/javascript/repo-admin-svn.js",
+    "assets/javascript/repo-admin-git.js",
+    "assets/javascript/repo-admin-workflows.js",
+    "assets/javascript/neural-chat-catalogs.js",
+    "assets/javascript/neural-chat-docs.js",
+    "assets/javascript/neural-chat-ui.js",
+    "assets/javascript/neural-chat-sessions.js",
+    "assets/javascript/neural-chat-profiles.js",
+    "assets/javascript/neural-chat-jules.js",
+    "assets/javascript/neural-chat-send.js",
+    "assets/javascript/neural-chat-activity.js",
+    "assets/javascript/jules-panel-ui.js",
+    "assets/javascript/jules-panel-repo.js",
+    "assets/javascript/jules-panel-sessions.js",
+    "assets/javascript/jules-panel-metrics.js",
+    "assets/javascript/jules-panel-kanban.js",
+    "assets/javascript/jules-panel-hub.js",
+    "assets/javascript/jules-panel-neural.js",
+    "assets/javascript/jules-panel-auth.js"
+]
+
+for filepath in files:
+    if not os.path.exists(filepath):
+        print(f"ERROR: File {filepath} not found.")
+        print("---")
+        continue
+
+    found = False
+    with open(filepath, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+        for i, line in enumerate(lines):
+            if '\\${' in line:
+                found = True
+                lnum = i + 1
+                before = line.strip()
+                after = line.replace('\\${', '${').strip()
+                print(f"FILE: {filepath}")
+                print(f"LINE: {lnum}")
+                print(f"BEFORE: {before}")
+                print(f"AFTER: {after}")
+                print("---")
+
+    if not found:
+        # Check for non-escaped ones too if needed, but the task is about fixing escaped ones
+        # print(f"AUDIT: {filepath} -> No escaped template literals found.")
+        # print("---")
+        pass

--- a/debug_chars.py
+++ b/debug_chars.py
@@ -1,0 +1,20 @@
+import sys
+
+def debug_file(path, search):
+    with open(path, 'rb') as f:
+        content = f.read()
+
+    index = content.find(search.encode('utf-8'))
+    if index != -1:
+        start = max(0, index - 10)
+        end = min(len(content), index + len(search) + 10)
+        chunk = content[start:end]
+        print(f"File: {path}")
+        print(f"Found at index {index}")
+        print(f"Chunk (repr): {chunk}")
+        print(f"Chunk (hex): {chunk.hex(' ')}")
+    else:
+        print(f"File: {path} - Not found")
+
+# Test for literal \${
+debug_file('assets/javascript/repo-admin-api.js', '\\${')

--- a/find_broken.py
+++ b/find_broken.py
@@ -1,0 +1,32 @@
+import os
+
+files = [
+    "assets/javascript/repo-admin-api.js", "assets/javascript/repo-admin-ui.js",
+    "assets/javascript/repo-admin-svn.js", "assets/javascript/repo-admin-git.js",
+    "assets/javascript/repo-admin-workflows.js", "assets/javascript/neural-chat-catalogs.js",
+    "assets/javascript/neural-chat-docs.js", "assets/javascript/neural-chat-ui.js",
+    "assets/javascript/neural-chat-sessions.js", "assets/javascript/neural-chat-profiles.js",
+    "assets/javascript/neural-chat-jules.js", "assets/javascript/neural-chat-send.js",
+    "assets/javascript/neural-chat-activity.js", "assets/javascript/jules-panel-ui.js",
+    "assets/javascript/jules-panel-repo.js", "assets/javascript/jules-panel-sessions.js",
+    "assets/javascript/jules-panel-metrics.js", "assets/javascript/jules-panel-kanban.js",
+    "assets/javascript/jules-panel-hub.js", "assets/javascript/jules-panel-neural.js",
+    "assets/javascript/jules-panel-auth.js"
+]
+
+broken_sequence = b'\\${'
+
+for f in files:
+    if not os.path.exists(f):
+        continue
+    with open(f, 'rb') as fd:
+        content = fd.read()
+
+    if broken_sequence in content:
+        print(f"BROKEN: {f} (Count: {content.count(broken_sequence)})")
+    else:
+        # Check if it has ${ at all
+        if b'${' in content:
+            print(f"CORRECT: {f}")
+        else:
+            print(f"NONE: {f}")

--- a/fix_and_report.py
+++ b/fix_and_report.py
@@ -1,0 +1,49 @@
+import os
+
+files = [
+    "assets/javascript/repo-admin-api.js",
+    "assets/javascript/repo-admin-ui.js",
+    "assets/javascript/repo-admin-svn.js",
+    "assets/javascript/repo-admin-git.js",
+    "assets/javascript/repo-admin-workflows.js",
+    "assets/javascript/neural-chat-catalogs.js",
+    "assets/javascript/neural-chat-docs.js",
+    "assets/javascript/neural-chat-ui.js",
+    "assets/javascript/neural-chat-sessions.js",
+    "assets/javascript/neural-chat-profiles.js",
+    "assets/javascript/neural-chat-jules.js",
+    "assets/javascript/neural-chat-send.js",
+    "assets/javascript/neural-chat-activity.js",
+    "assets/javascript/jules-panel-ui.js",
+    "assets/javascript/jules-panel-repo.js",
+    "assets/javascript/jules-panel-sessions.js",
+    "assets/javascript/jules-panel-metrics.js",
+    "assets/javascript/jules-panel-kanban.js",
+    "assets/javascript/jules-panel-hub.js",
+    "assets/javascript/jules-panel-neural.js",
+    "assets/javascript/jules-panel-auth.js"
+]
+
+results = []
+
+for filepath in files:
+    if not os.path.exists(filepath):
+        results.append((filepath, "NOT FOUND"))
+        continue
+
+    with open(filepath, 'rb') as f:
+        content = f.read()
+
+    count = content.count(b'\\${')
+    if count > 0:
+        new_content = content.replace(b'\\${', b'${')
+        with open(filepath, 'wb') as f:
+            f.write(new_content)
+        results.append((filepath, count))
+    else:
+        results.append((filepath, 0))
+
+print(f"{'FILE':<45} | {'INSTANCES':<10}")
+print("-" * 58)
+for f, c in results:
+    print(f"{f:<45} | {c:<10}")

--- a/fix_final.py
+++ b/fix_final.py
@@ -1,0 +1,40 @@
+import os
+
+files = [
+    "assets/javascript/repo-admin-api.js", "assets/javascript/repo-admin-ui.js",
+    "assets/javascript/repo-admin-svn.js", "assets/javascript/repo-admin-git.js",
+    "assets/javascript/repo-admin-workflows.js", "assets/javascript/neural-chat-catalogs.js",
+    "assets/javascript/neural-chat-docs.js", "assets/javascript/neural-chat-ui.js",
+    "assets/javascript/neural-chat-sessions.js", "assets/javascript/neural-chat-profiles.js",
+    "assets/javascript/neural-chat-jules.js", "assets/javascript/neural-chat-send.js",
+    "assets/javascript/neural-chat-activity.js", "assets/javascript/jules-panel-ui.js",
+    "assets/javascript/jules-panel-repo.js", "assets/javascript/jules-panel-sessions.js",
+    "assets/javascript/jules-panel-metrics.js", "assets/javascript/jules-panel-kanban.js",
+    "assets/javascript/jules-panel-hub.js", "assets/javascript/jules-panel-neural.js",
+    "assets/javascript/jules-panel-auth.js"
+]
+
+target = bytes([0x5C, 0x24, 0x7B]) # \${
+replacement = bytes([0x24, 0x7B])   # ${
+
+print(f"{'FILE':<45} | {'FIXED':<10}")
+print("-" * 58)
+
+total = 0
+for f in files:
+    if not os.path.exists(f): continue
+    with open(f, 'rb') as fd:
+        content = fd.read()
+
+    count = content.count(target)
+    if count > 0:
+        new_content = content.replace(target, replacement)
+        with open(f, 'wb') as fd:
+            fd.write(new_content)
+        print(f"{f:<45} | {count:<10}")
+        total += count
+    else:
+        print(f"{f:<45} | 0")
+
+print("-" * 58)
+print(f"{'TOTAL':<45} | {total:<10}")

--- a/fix_literals.py
+++ b/fix_literals.py
@@ -1,0 +1,51 @@
+import os
+
+files = [
+    "assets/javascript/repo-admin-api.js",
+    "assets/javascript/repo-admin-ui.js",
+    "assets/javascript/repo-admin-svn.js",
+    "assets/javascript/repo-admin-git.js",
+    "assets/javascript/repo-admin-workflows.js",
+    "assets/javascript/neural-chat-catalogs.js",
+    "assets/javascript/neural-chat-docs.js",
+    "assets/javascript/neural-chat-ui.js",
+    "assets/javascript/neural-chat-sessions.js",
+    "assets/javascript/neural-chat-profiles.js",
+    "assets/javascript/neural-chat-jules.js",
+    "assets/javascript/neural-chat-send.js",
+    "assets/javascript/neural-chat-activity.js",
+    "assets/javascript/jules-panel-ui.js",
+    "assets/javascript/jules-panel-repo.js",
+    "assets/javascript/jules-panel-sessions.js",
+    "assets/javascript/jules-panel-metrics.js",
+    "assets/javascript/jules-panel-kanban.js",
+    "assets/javascript/jules-panel-hub.js",
+    "assets/javascript/jules-panel-neural.js",
+    "assets/javascript/jules-panel-auth.js"
+]
+
+print(f"{'FILE':<45} | {'INSTANCES':<10}")
+print("-" * 58)
+
+total_fixed = 0
+
+for filepath in files:
+    if not os.path.exists(filepath):
+        continue
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    count = content.count('\\${')
+    if count > 0:
+        new_content = content.replace('\\${', '${')
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        print(f"{filepath:<45} | {count:<10}")
+        total_fixed += count
+    else:
+        # Check if the file exists but has no escaped literals
+        print(f"{filepath:<45} | 0")
+
+print("-" * 58)
+print(f"{'TOTAL':<45} | {total_fixed:<10}")

--- a/full_audit.txt
+++ b/full_audit.txt
@@ -1,0 +1,875 @@
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 74
+BEFORE: el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">\${s.displayName || s.name.split('/').pop()}</span>\${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+AFTER: el.innerHTML = `<span class="repo-dot"></span><span style="flex:1; overflow:hidden; text-overflow:ellipsis;">${s.displayName || s.name.split('/').pop()}</span>${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; opacity:0.5"></i>' : ''}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 88
+BEFORE: if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → \${sourceName.split('/').pop()}`, "info");
+AFTER: if (oldRepo && oldRepo !== sourceName) addTel("REPO", `Contexto cambiado → ${sourceName.split('/').pop()}`, "info");
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 89
+BEFORE: else addTel("SYSTEM", `Contexto: \${sourceName.split('/').pop()}`, "info");
+AFTER: else addTel("SYSTEM", `Contexto: ${sourceName.split('/').pop()}`, "info");
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 100
+BEFORE: if(sessCtx) sessCtx.textContent = `\${displayLabel}: cargando...`;
+AFTER: if(sessCtx) sessCtx.textContent = `${displayLabel}: cargando...`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 110
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${e.target.value}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${e.target.value}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 118
+BEFORE: branchSelect.innerHTML = branches.map(b => `<option value="\${b.name}" \${b.name === defaultBranch ? 'selected' : ''}>\${b.name}\${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+AFTER: branchSelect.innerHTML = branches.map(b => `<option value="${b.name}" ${b.name === defaultBranch ? 'selected' : ''}>${b.name}${b.name === defaultBranch ? ' ★' : ''}</option>`).join('');
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 121
+BEFORE: if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>\${branches.length} ramas</span>`;
+AFTER: if(branchMeta) branchMeta.innerHTML = `<span class="u-dot"></span><span>${branches.length} ramas</span>`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 123
+BEFORE: if(sessCtx) sessCtx.textContent = `\${displayLabel}: \${activeBranch}`;
+AFTER: if(sessCtx) sessCtx.textContent = `${displayLabel}: ${activeBranch}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 138
+BEFORE: item.className = `custom-dropdown-item \${!isInstalled ? 'disabled' : ''}`;
+AFTER: item.className = `custom-dropdown-item ${!isInstalled ? 'disabled' : ''}`;
+---
+FILE: assets/javascript/jules-panel-repo.js
+LINE: 144
+BEFORE: item.innerHTML = `<span>\${s.displayName || s.name.split('/').pop()}</span> \${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+AFTER: item.innerHTML = `<span>${s.displayName || s.name.split('/').pop()}</span> ${!isInstalled ? '<i class="fas fa-lock" style="font-size:10px; float:right; margin-top:3px"></i>' : ''}`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 18
+BEFORE: return `<span class="session-badge session-badge--\${cfg.cls}">
+AFTER: return `<span class="session-badge session-badge--${cfg.cls}">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 19
+BEFORE: \${cfg.icon} \${cfg.label}
+AFTER: ${cfg.icon} ${cfg.label}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 38
+BEFORE: const stickyBadge = document.getElementById(`sticky-badge-\${idSafe}`);
+AFTER: const stickyBadge = document.getElementById(`sticky-badge-${idSafe}`);
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 138
+BEFORE: return `<div class="\${cls}">\${escapeHtml(line)}</div>`;
+AFTER: return `<div class="${cls}">${escapeHtml(line)}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 145
+BEFORE: +\${hiddenCount} líneas más —
+AFTER: +${hiddenCount} líneas más —
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 146
+BEFORE: <a href="\${session?.url || '#'}" target="_blank"
+AFTER: <a href="${session?.url || '#'}" target="_blank"
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 160
+BEFORE: \${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+AFTER: ${msg ? `<span style="color:#6b7280;font-weight:400;font-size:10px;">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 161
+BEFORE: — \${escapeHtml(msg)}</span>` : ''}
+AFTER: — ${escapeHtml(msg)}</span>` : ''}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 165
+BEFORE: \${diffLinesHtml}
+AFTER: ${diffLinesHtml}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 166
+BEFORE: \${moreHtml}
+AFTER: ${moreHtml}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 181
+BEFORE: \${(s.index || 0) + 1}.
+AFTER: ${(s.index || 0) + 1}.
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 185
+BEFORE: \${s.title || 'Sin título'}
+AFTER: ${s.title || 'Sin título'}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 187
+BEFORE: \${s.description ? `
+AFTER: ${s.description ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 189
+BEFORE: \${s.description}
+AFTER: ${s.description}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 192
+BEFORE: <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('\${activity.name?.split('/activities/')[0]}', \${(s.index || 0) + 1}, '\${escapeHtml(s.title)}')">
+AFTER: <button class="btn-icon" title="Comentar en este paso" onclick="commentOnStep('${activity.name?.split('/activities/')[0]}', ${(s.index || 0) + 1}, '${escapeHtml(s.title)}')">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 203
+BEFORE: 📋 Plan generado (\${steps.length} pasos)
+AFTER: 📋 Plan generado (${steps.length} pasos)
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 205
+BEFORE: <div>\${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+AFTER: <div>${stepsHtml || '<span style="color:#6b7280">Sin pasos</span>'}</div>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 216
+BEFORE: html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+AFTER: html = `<div class="activity-entry activity-entry--user prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 221
+BEFORE: html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">\${parsed}</div>`;
+AFTER: html = `<div class="activity-entry activity-entry--agent prose-invert" style="overflow-x: auto; max-width: 100%; word-break: break-word;">${parsed}</div>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 235
+BEFORE: \${parsedTitle}
+AFTER: ${parsedTitle}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 236
+BEFORE: \${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">\${parsedDesc}</div>` : ''}
+AFTER: ${parsedDesc ? `<div style="color:#9ca3af;margin-top:4px;">${parsedDesc}</div>` : ''}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 238
+BEFORE: \${bash ? `
+AFTER: ${bash ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 241
+BEFORE: $ \${escapeHtml(bash.command || '')}
+AFTER: $ ${escapeHtml(bash.command || '')}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 242
+BEFORE: <span style="color:\${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+AFTER: <span style="color:${bash.exitCode === 0 ? '#10b981' : '#ef4444'}">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 243
+BEFORE: [exit \${bash.exitCode ?? '?'}]
+AFTER: [exit ${bash.exitCode ?? '?'}]
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 246
+BEFORE: <pre class="activity-code">\${escapeHtml(bash.output || "")}</pre>
+AFTER: <pre class="activity-code">${escapeHtml(bash.output || "")}</pre>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 260
+BEFORE: \${parsed ? `
+AFTER: ${parsed ? `
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 264
+BEFORE: \${parsed}
+AFTER: ${parsed}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 272
+BEFORE: ❌ Sesión fallida: \${escapeHtml(reason)}
+AFTER: ❌ Sesión fallida: ${escapeHtml(reason)}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 282
+BEFORE: \${escapeHtml(desc)}
+AFTER: ${escapeHtml(desc)}
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 313
+BEFORE: <button onclick="approveJulesPlan('\${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+AFTER: <button onclick="approveJulesPlan('${sessionId}')" class="btn btn-primary btn-sm" style="background: var(--amber); color: #000; box-shadow: 0 0 15px rgba(245, 158, 11, 0.4); min-height: 32px; padding: 4px 12px; border-radius: 6px; font-weight: 800;">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 425
+BEFORE: return `<tr onclick="openDrawer('\${s.name}')"><td><span class="sid">\${s.name.split('/').pop()}</span></td><td class="tdesc">\${escapeHtml(s.title || s.prompt)}</td><td class="tmono">\${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">\${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>\${statusLabel}</span></td><td class="tmono">\${getTimeAgo(s.createTime)}</td><td class="tmono">\${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+AFTER: return `<tr onclick="openDrawer('${s.name}')"><td><span class="sid">${s.name.split('/').pop()}</span></td><td class="tdesc">${escapeHtml(s.title || s.prompt)}</td><td class="tmono">${s.sourceContext?.source?.split('/').pop() || '---'}</td><td class="tmono">${s.sourceContext?.githubRepoContext?.startingBranch || '---'}</td><td><span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}"><span class="pulse-dot"></span>${statusLabel}</span></td><td class="tmono">${getTimeAgo(s.createTime)}</td><td class="tmono">${new Date(s.createTime).toLocaleDateString()}</td></tr>`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 434
+BEFORE: <div onclick="openDrawer('\${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+AFTER: <div onclick="openDrawer('${s.name}')" style="padding:14px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:6px">
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 436
+BEFORE: <span class="sid">\${s.name.split('/').pop()}</span>
+AFTER: <span class="sid">${s.name.split('/').pop()}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 437
+BEFORE: <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${statusLabel}</span>
+AFTER: <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${statusLabel}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 439
+BEFORE: <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">\${escapeHtml(s.title || s.prompt)}</div>
+AFTER: <div style="font-weight:600; color:var(--text); font-size:13px" class="tdesc">${escapeHtml(s.title || s.prompt)}</div>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 441
+BEFORE: <span>\${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+AFTER: <span>${s.sourceContext?.source?.split('/').pop() || '---'}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 442
+BEFORE: <span>\${getTimeAgo(s.createTime)}</span>
+AFTER: <span>${getTimeAgo(s.createTime)}</span>
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 496
+BEFORE: else if (act.progressUpdated) activityType = `Progreso: \${act.progressUpdated.title}`;
+AFTER: else if (act.progressUpdated) activityType = `Progreso: ${act.progressUpdated.title}`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 502
+BEFORE: const separator = `\n--- Actividad: \${activityType} ---\n`;
+AFTER: const separator = `\n--- Actividad: ${activityType} ---\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 506
+BEFORE: content += `\${act.userMessaged.userMessage}\n`;
+AFTER: content += `${act.userMessaged.userMessage}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 508
+BEFORE: content += `\${act.agentMessaged.agentMessage}\n`;
+AFTER: content += `${act.agentMessaged.agentMessage}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 510
+BEFORE: if (act.progressUpdated.description) content += `\${act.progressUpdated.description}\n`;
+AFTER: if (act.progressUpdated.description) content += `${act.progressUpdated.description}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 513
+BEFORE: content += `PASOS:\n\${steps.map(s => `\${(s.index || 0) + 1}. \${s.title}: \${s.description || ''}`).join('\n')}\n`;
+AFTER: content += `PASOS:\n${steps.map(s => `${(s.index || 0) + 1}. ${s.title}: ${s.description || ''}`).join('\n')}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 515
+BEFORE: content += `Commit: \${act.sessionCompleted.commitMessage || '---'}\n`;
+AFTER: content += `Commit: ${act.sessionCompleted.commitMessage || '---'}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 517
+BEFORE: content += `Razón: \${act.sessionFailed.reason || 'Desconocida'}\n`;
+AFTER: content += `Razón: ${act.sessionFailed.reason || 'Desconocida'}\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 523
+BEFORE: content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n\${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+AFTER: content += `\nCÓDIGO (DIFF):\n\`\`\`diff\n${art.changeSet.gitPatch.unidiffPatch}\n\`\`\`\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 526
+BEFORE: content += `\nCOMANDO: \${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n\${art.bashOutput.output}\n\`\`\`\n`;
+AFTER: content += `\nCOMANDO: ${art.bashOutput.command}\nOUTPUT:\n\`\`\`\n${art.bashOutput.output}\n\`\`\`\n`;
+---
+FILE: assets/javascript/jules-panel-sessions.js
+LINE: 560
+BEFORE: input.value = `Respecto al paso \${stepIndex} (\${stepTitle}): ` + input.value;
+AFTER: input.value = `Respecto al paso ${stepIndex} (${stepTitle}): ` + input.value;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 16
+BEFORE: if($("m-success-rate")) $("m-success-rate").textContent = `\${successRate}%`;
+AFTER: if($("m-success-rate")) $("m-success-rate").textContent = `${successRate}%`;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 17
+BEFORE: if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `\${Math.round(totalTokens/1000)}k` : totalTokens;
+AFTER: if($("m-tokens")) $("m-tokens").textContent = totalTokens > 1000 ? `${Math.round(totalTokens/1000)}k` : totalTokens;
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 26
+BEFORE: if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `\${doneP} 100`);
+AFTER: if($("donut-done")) $("donut-done").setAttribute("stroke-dasharray", `${doneP} 100`);
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 28
+BEFORE: $("donut-error").setAttribute("stroke-dasharray", `\${errorP} 100`);
+AFTER: $("donut-error").setAttribute("stroke-dasharray", `${errorP} 100`);
+---
+FILE: assets/javascript/jules-panel-metrics.js
+LINE: 29
+BEFORE: $("donut-error").setAttribute("stroke-dashoffset", `-\${doneP}`);
+AFTER: $("donut-error").setAttribute("stroke-dashoffset", `-${doneP}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 76
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 81
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 87
+BEFORE: const col = $(`col-\${targetColId}`);
+AFTER: const col = $(`col-${targetColId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 187
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${branch}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${branch}`;
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 330
+BEFORE: const colEl = $(`kb-\${colId}`), countEl = $(`kb-count-\${colId}`), mCountEl = $(`m-count-\${colId}`);
+AFTER: const colEl = $(`kb-${colId}`), countEl = $(`kb-count-${colId}`), mCountEl = $(`m-count-${colId}`);
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 352
+BEFORE: <div class="kb-card \${colId} \${isArchived ? 'archived' : ''}"
+AFTER: <div class="kb-card ${colId} ${isArchived ? 'archived' : ''}"
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 353
+BEFORE: \${canDrag ? `draggable="true" ondragstart="onDragStart(event, '\${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+AFTER: ${canDrag ? `draggable="true" ondragstart="onDragStart(event, '${sid}')" ondragend="this.classList.remove('dragging')"` : ''}
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 354
+BEFORE: onclick="openDrawer('\${s.name}')">
+AFTER: onclick="openDrawer('${s.name}')">
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 356
+BEFORE: <div class="kb-card-id">#\${sid}\${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+AFTER: <div class="kb-card-id">#${sid}${isArchived ? '<span class="archived-badge">Archived</span>' : ''}</div>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 357
+BEFORE: <span class="sbadge \${s.state.toLowerCase().replace(/_/g, '-')}">\${s.state}</span>
+AFTER: <span class="sbadge ${s.state.toLowerCase().replace(/_/g, '-')}">${s.state}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 359
+BEFORE: <div class="kb-card-task">\${escapeHtml(s.title || s.prompt)}</div>
+AFTER: <div class="kb-card-task">${escapeHtml(s.title || s.prompt)}</div>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 361
+BEFORE: <span class="kb-card-repo">\${repo}</span>
+AFTER: <span class="kb-card-repo">${repo}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 362
+BEFORE: <span class="kb-card-time">\${getTimeAgo(s.createTime)}</span>
+AFTER: <span class="kb-card-time">${getTimeAgo(s.createTime)}</span>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 365
+BEFORE: \${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('\${archiveId}')">Restaurar</button>` : ''}
+AFTER: ${isArchived ? `<button class="kb-action-btn" style="color:var(--amber)" onclick="event.stopPropagation(); restoreArchivedCard('${archiveId}')">Restaurar</button>` : ''}
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 366
+BEFORE: <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('\${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+AFTER: <button class="kb-action-btn btn-relaunch" onclick="event.stopPropagation(); relaunchJules('${encodeURIComponent(JSON.stringify(s))}')">Relanzar Jules</button>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 367
+BEFORE: <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '\${sid}'); localStorage.setItem('hy_neural_session_id', '\${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+AFTER: <button class="kb-action-btn" onclick="event.stopPropagation(); const cid = localStorage.getItem('hy_active_claude_session_id'); if (cid) localStorage.setItem('hy_neural_session_id_' + cid, '${sid}'); localStorage.setItem('hy_neural_session_id', '${sid}'); localStorage.setItem('hy_neural_active', 'true'); switchView('chat');">Ver Neural</button>
+---
+FILE: assets/javascript/jules-panel-kanban.js
+LINE: 379
+BEFORE: const col = $(`col-\${colId}`);
+AFTER: const col = $(`col-${colId}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 11
+BEFORE: const panel = $(`panel-\${tabMap[tabId]}`);
+AFTER: const panel = $(`panel-${tabMap[tabId]}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 20
+BEFORE: const panel = $(`panel-\${tabMap[tabId]}`);
+AFTER: const panel = $(`panel-${tabMap[tabId]}`);
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 31
+BEFORE: } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: \${e.message}</div>`; }
+AFTER: } catch (e) { panel.innerHTML = `<div style="padding:20px; color:var(--red);">Error: ${e.message}</div>`; }
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 36
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 38
+BEFORE: $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${pr.title}</div><div style="font-size:11px; color:var(--text3);">#\${pr.number} por \${pr.user.login} • \${getTimeAgo(pr.updated_at)}</div></div><a href="\${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+AFTER: $('panel-pr').innerHTML = prs.map(pr => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${pr.title}</div><div style="font-size:11px; color:var(--text3);">#${pr.number} por ${pr.user.login} • ${getTimeAgo(pr.updated_at)}</div></div><a href="${pr.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin PRs</div>';
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 44
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 46
+BEFORE: $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">\${issue.title}</div><div style="font-size:11px; color:var(--text3);">#\${issue.number} • \${getTimeAgo(issue.created_at)}</div></div><a href="\${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+AFTER: $('panel-issues').innerHTML = issues.map(issue => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);">${issue.title}</div><div style="font-size:11px; color:var(--text3);">#${issue.number} • ${getTimeAgo(issue.created_at)}</div></div><a href="${issue.html_url}" target="_blank" class="btn btn-ghost btn-sm">Ver ↗</a></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Sin issues</div>';
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 52
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/branches?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 54
+BEFORE: $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">\${b.name}</span>\${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+AFTER: $('panel-branches').innerHTML = branches.map(b => `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:10px;"><span style="font-family:var(--font-mono); font-size:13px; color:var(--text2);">${b.name}</span>${b.protected ? '<span class="nav-badge" style="background:var(--surface-active); color:var(--accent2); font-size:9px;">🔒</span>' : ''}</div>`).join('');
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 59
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/\${owner}/\${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/repos/${owner}/${repo}/actions/runs?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 63
+BEFORE: return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:\${color}">●</span> \${run.name} #\${run.run_number}</div><div style="font-size:11px; color:var(--text3);">\${run.head_branch} • \${getTimeAgo(run.updated_at)}</div></div><a href="\${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+AFTER: return `<div style="padding:12px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;"><div><div style="font-weight:600; color:var(--text);"><span style="color:${color}">●</span> ${run.name} #${run.run_number}</div><div style="font-size:11px; color:var(--text3);">${run.head_branch} • ${getTimeAgo(run.updated_at)}</div></div><a href="${run.html_url}" target="_blank" class="btn btn-ghost btn-sm">Logs ↗</a></div>`;
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 69
+BEFORE: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer \${token}` } }));
+AFTER: const res = await window.GHQueue.enqueue(() => fetch(`https://api.github.com/notifications?per_page=20`, { headers: { Authorization: `Bearer ${token}` } }));
+---
+FILE: assets/javascript/jules-panel-hub.js
+LINE: 71
+BEFORE: $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">\${n.repository.name}</div><div style="font-weight:600; color:var(--text);">\${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+AFTER: $('panel-notifs').innerHTML = notifs.map(n => `<div style="padding:12px; border-bottom:1px solid var(--border);"><div style="font-size:10px; color:var(--text3);">${n.repository.name}</div><div style="font-weight:600; color:var(--text);">${n.subject.title}</div></div>`).join('') || '<div style="padding:40px; text-align:center; color:var(--text3);">Estás al día</div>';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 19
+BEFORE: localStorage.setItem(`hy_neural_context_\${sessionId}`, JSON.stringify(sessionData));
+AFTER: localStorage.setItem(`hy_neural_context_${sessionId}`, JSON.stringify(sessionData));
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 54
+BEFORE: const saved = localStorage.getItem(`hy_neural_context_\${sessionId}`);
+AFTER: const saved = localStorage.getItem(`hy_neural_context_${sessionId}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 82
+BEFORE: const analyzedKey = `v2_jules_analyzed_\${output.session_id}_\${output.status}`;
+AFTER: const analyzedKey = `v2_jules_analyzed_${output.session_id}_${output.status}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 86
+BEFORE: window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #\${output.session_id})...` });
+AFTER: window.chatV2Messages.push({ role: 'system', content: `Analizando resultado de Jules (Sesión #${output.session_id})...` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 91
+BEFORE: const prompt = `Jules ha completado una operación (Estado: \${output.status}).\n\nDETALLES:\n- Sesión: #\${output.session_id}\n- Tarea: \${output.title}\n- Repo: \${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+AFTER: const prompt = `Jules ha completado una operación (Estado: ${output.status}).\n\nDETALLES:\n- Sesión: #${output.session_id}\n- Tarea: ${output.title}\n- Repo: ${output.repo}\n\nAnaliza el resultado y prepara un resumen accionable.`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 99
+BEFORE: window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n\${analysis}` });
+AFTER: window.chatV2Messages.push({ role: 'assistant', content: `[ANÁLISIS AUTOMÁTICO JULES]\n\n${analysis}` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 112
+BEFORE: status.textContent = `[\${tel.tag}] \${tel.msg}`;
+AFTER: status.textContent = `[${tel.tag}] ${tel.msg}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 125
+BEFORE: const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: \${t.blocks.join(', ')}` : 'No bloquea a nadie';
+AFTER: const blockingInfo = (t.blocks && t.blocks.length > 0) ? `Bloquea a: ${t.blocks.join(', ')}` : 'No bloquea a nadie';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 126
+BEFORE: const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: \${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+AFTER: const blockedByInfo = (t.blocked_by && t.blocked_by.length > 0) ? `Bloqueada por: ${t.blocked_by.join(', ')}` : 'No tiene bloqueos';
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 129
+BEFORE: `ID: #\${t.id}\n` +
+AFTER: `ID: #${t.id}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 130
+BEFORE: `Título: \${t.titulo || t.title}\n` +
+AFTER: `Título: ${t.titulo || t.title}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 131
+BEFORE: `Descripción: \${t.descripcion || t.description}\n` +
+AFTER: `Descripción: ${t.descripcion || t.description}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 132
+BEFORE: `Criterios de Aceptación: \${t.acceptance_criteria || 'N/A'}\n` +
+AFTER: `Criterios de Aceptación: ${t.acceptance_criteria || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 133
+BEFORE: `Subtareas: \${JSON.stringify(t.subtasks || [])}\n` +
+AFTER: `Subtareas: ${JSON.stringify(t.subtasks || [])}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 134
+BEFORE: `Estado: \${t.estado || t.status}\n` +
+AFTER: `Estado: ${t.estado || t.status}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 135
+BEFORE: `Prioridad: \${t.prioridad || t.priority}\n` +
+AFTER: `Prioridad: ${t.prioridad || t.priority}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 136
+BEFORE: `Rama: \${t.rama || 'N/A'}\n` +
+AFTER: `Rama: ${t.rama || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 137
+BEFORE: `Milestone: \${t.milestone || 'N/A'}\n` +
+AFTER: `Milestone: ${t.milestone || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 138
+BEFORE: `Repositorio: \${t.repository || t.repo || 'N/A'}\n` +
+AFTER: `Repositorio: ${t.repository || t.repo || 'N/A'}\n` +
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 139
+BEFORE: `Dependencias: \${blockingInfo} | \${blockedByInfo}\n`;
+AFTER: `Dependencias: ${blockingInfo} | ${blockedByInfo}\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 147
+BEFORE: systemPrompt += `\n### Historial reciente de Jules (Sesión #\${linkedSid}):\n\${logs}\n`;
+AFTER: systemPrompt += `\n### Historial reciente de Jules (Sesión #${linkedSid}):\n${logs}\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 168
+BEFORE: const endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+AFTER: const endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 183
+BEFORE: if (!isOllama) headers["Authorization"] = `Bearer \${apiKey}`;
+AFTER: if (!isOllama) headers["Authorization"] = `Bearer ${apiKey}`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 191
+BEFORE: if (!res.ok) throw new Error(`API Error: \${res.status}`);
+AFTER: if (!res.ok) throw new Error(`API Error: ${res.status}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 282
+BEFORE: thinking.textContent = retryCount > 0 ? `REINTENTANDO (\${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+AFTER: thinking.textContent = retryCount > 0 ? `REINTENTANDO (${retryCount})...` : "CLAUDE ESTÁ PROCESANDO...";
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 299
+BEFORE: content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n\${m.content}` : m.content
+AFTER: content: m.role === 'jules' ? `[JULES ACTIVITY CONTEXT]\n${m.content}` : m.content
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 304
+BEFORE: const contextPrefix = `[CONTEXTO TAREA #\${t.id}: \${t.titulo}]\n`;
+AFTER: const contextPrefix = `[CONTEXTO TAREA #${t.id}: ${t.titulo}]\n`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 321
+BEFORE: let endpoint = isAnthropic ? `\${baseUrl}/messages` : `\${baseUrl}/chat/completions`;
+AFTER: let endpoint = isAnthropic ? `${baseUrl}/messages` : `${baseUrl}/chat/completions`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 330
+BEFORE: 'Authorization': `Bearer \${apiKey}`
+AFTER: 'Authorization': `Bearer ${apiKey}`
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 360
+BEFORE: throw new Error(errData.error?.message || `HTTP \${res.status}`);
+AFTER: throw new Error(errData.error?.message || `HTTP ${res.status}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 368
+BEFORE: addTel("SYSTEM", `Reintentando comunicación (\${retryCount + 1}/2)...`, "warn");
+AFTER: addTel("SYSTEM", `Reintentando comunicación (${retryCount + 1}/2)...`, "warn");
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 372
+BEFORE: window.chatV2Messages.push({ role: 'system', content: `❌ Error: \${e.message}` });
+AFTER: window.chatV2Messages.push({ role: 'system', content: `❌ Error: ${e.message}` });
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 429
+BEFORE: finalHtml += `<div class="thinking-block">\${escapeHtml(thinkingContent)}</div>`;
+AFTER: finalHtml += `<div class="thinking-block">${escapeHtml(thinkingContent)}</div>`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 495
+BEFORE: return `<div class="message-system">\${m.content}</div>`;
+AFTER: return `<div class="message-system">${m.content}</div>`;
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 517
+BEFORE: <div class="\${roleClass}">
+AFTER: <div class="${roleClass}">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 518
+BEFORE: <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: \${labelColor}">
+AFTER: <div style="font-size: 10px; font-weight: 800; opacity: 0.7; margin-bottom: 8px; letter-spacing: 0.05em; color: ${labelColor}">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 519
+BEFORE: \${label}
+AFTER: ${label}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 522
+BEFORE: \${m.thinking ? `<div class="thinking-block">\${escapeHtml(m.thinking)}</div>` : ''}
+AFTER: ${m.thinking ? `<div class="thinking-block">${escapeHtml(m.thinking)}</div>` : ''}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 523
+BEFORE: \${marked.parse(m.content)}
+AFTER: ${marked.parse(m.content)}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 551
+BEFORE: \${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+AFTER: ${isActive ? `<div style="position: absolute; top: 0; left: 0; width: 3px; height: 100%; background: var(--accent);"></div>` : ''}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 554
+BEFORE: <div id="drawer-name-display-\${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('\${s.id}')">
+AFTER: <div id="drawer-name-display-${s.id}" style="font-size: 14px; font-weight: 700; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; display: flex; align-items: center; gap: 8px;" onclick="restoreSessionFromDrawer('${s.id}')">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 555
+BEFORE: \${s.name}
+AFTER: ${s.name}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 557
+BEFORE: <input id="drawer-name-edit-\${s.id}" type="text" class="cfg-input hidden" value="\${s.name}" onblur="saveRenameFromDrawer('\${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+AFTER: <input id="drawer-name-edit-${s.id}" type="text" class="cfg-input hidden" value="${s.name}" onblur="saveRenameFromDrawer('${s.id}')" onkeydown="if(event.key==='Enter') this.blur()" style="height: 28px; font-size: 13px; padding: 4px 8px; margin-top: 4px;">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 559
+BEFORE: <span style="font-size: 9px; color: \${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+AFTER: <span style="font-size: 9px; color: ${statusColor}; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 4px;">
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 560
+BEFORE: \${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} \${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+AFTER: ${isActive ? `<span class="u-dot" style="width:5px; height:5px;"></span>` : ''} ${isActive ? 'ACTIVA' : 'ARCHIVADA'}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 562
+BEFORE: <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#\${s.id}</span>
+AFTER: <span style="font-size: 9px; color: var(--text3); font-family: var(--font-mono);">#${s.id}</span>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 566
+BEFORE: <button onclick="renameFromDrawer('\${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+AFTER: <button onclick="renameFromDrawer('${s.id}')" class="icon-btn" title="Renombrar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border);">✏️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 567
+BEFORE: <button onclick="archiveFromDrawer('\${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); \${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+AFTER: <button onclick="archiveFromDrawer('${s.id}')" class="icon-btn" title="Archivar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); ${!isActive ? 'opacity: 0.2; pointer-events: none;' : ''}">🗄️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 568
+BEFORE: <button onclick="deleteFromDrawer('\${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+AFTER: <button onclick="deleteFromDrawer('${s.id}')" class="icon-btn" title="Eliminar" style="width: 28px; height: 28px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); color: var(--red);">🗑️</button>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 573
+BEFORE: <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> \${s.task_title}
+AFTER: <i class="fas fa-tasks" style="font-size: 8px; color: var(--accent2);"></i> ${s.task_title}
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 575
+BEFORE: <span style="color: var(--text3);">\${new Date(s.start).toLocaleDateString()}</span>
+AFTER: <span style="color: var(--text3);">${new Date(s.start).toLocaleDateString()}</span>
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 582
+BEFORE: $(`drawer-name-display-\${sid}`).classList.add('hidden');
+AFTER: $(`drawer-name-display-${sid}`).classList.add('hidden');
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 583
+BEFORE: const edit = $(`drawer-name-edit-\${sid}`);
+AFTER: const edit = $(`drawer-name-edit-${sid}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 589
+BEFORE: const edit = $(`drawer-name-edit-\${sid}`);
+AFTER: const edit = $(`drawer-name-edit-${sid}`);
+---
+FILE: assets/javascript/jules-panel-neural.js
+LINE: 637
+BEFORE: localStorage.setItem(`hy_neural_session_id_\${claudeId}`, s.id);
+AFTER: localStorage.setItem(`hy_neural_session_id_${claudeId}`, s.id);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 30
+BEFORE: addTel("SYSTEM", `Iniciado como \${user.login}`, "success");
+AFTER: addTel("SYSTEM", `Iniciado como ${user.login}`, "success");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 81
+BEFORE: if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+AFTER: if (payload.user_note) formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 83
+BEFORE: formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+AFTER: formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 86
+BEFORE: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+AFTER: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 92
+BEFORE: formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #\${task.id} - \${task.titulo || task.title}\n`;
+AFTER: formattedPrompt = `He vinculado esta tarea para su análisis técnico:\n\n📌 TAREA: #${task.id} - ${task.titulo || task.title}\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 93
+BEFORE: if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: \${task.descripcion}\n`;
+AFTER: if (task.descripcion) formattedPrompt += `📝 DESCRIPCIÓN: ${task.descripcion}\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 102
+BEFORE: src.name === targetRepo || src.name === `sources/github/\${targetRepo}` || src.displayName === targetRepo
+AFTER: src.name === targetRepo || src.name === `sources/github/${targetRepo}` || src.displayName === targetRepo
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 107
+BEFORE: const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/\${targetRepo}`;
+AFTER: const sourceName = targetRepo.startsWith('sources/') ? targetRepo : `sources/github/${targetRepo}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 126
+BEFORE: sessCtx.textContent = `\${repoLabel}: \${targetBranch}`;
+AFTER: sessCtx.textContent = `${repoLabel}: ${targetBranch}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 128
+BEFORE: addTel("SYSTEM", `Rama auto-ajustada a \${targetBranch} (Tarea #\${task.id})`, "info");
+AFTER: addTel("SYSTEM", `Rama auto-ajustada a ${targetBranch} (Tarea #${task.id})`, "info");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 146
+BEFORE: formattedPrompt = `Crea la branch \${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+AFTER: formattedPrompt = `Crea la branch ${targetBranch} a partir de main antes de empezar.\n\n` + formattedPrompt;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 186
+BEFORE: $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+AFTER: $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 253
+BEFORE: $('neural-banner-task').textContent = `Tarea #\${task.id}: \${task.titulo || task.title}`;
+AFTER: $('neural-banner-task').textContent = `Tarea #${task.id}: ${task.titulo || task.title}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 273
+BEFORE: formattedPrompt += `[NOTA DEL USUARIO]\n\${payload.user_note}\n\n`;
+AFTER: formattedPrompt += `[NOTA DEL USUARIO]\n${payload.user_note}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 277
+BEFORE: formattedPrompt += `[CONTEXTO NEURAL]\n\n\${payload.session_context}\n\n`;
+AFTER: formattedPrompt += `[CONTEXTO NEURAL]\n\n${payload.session_context}\n\n`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 281
+BEFORE: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n\${payload.claude_response}`;
+AFTER: formattedPrompt += `[RESPUESTA DE CLAUDE]\n\n${payload.claude_response}`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 337
+BEFORE: const avatarUrl = user.avatar_url || `https://github.com/\${user.login}.png`;
+AFTER: const avatarUrl = user.avatar_url || `https://github.com/${user.login}.png`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 340
+BEFORE: $('sb-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('sb-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 348
+BEFORE: $('mob-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('mob-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 353
+BEFORE: $('hdr-avatar').innerHTML = `<img src="\${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+AFTER: $('hdr-avatar').innerHTML = `<img src="${avatarUrl}" style="width:100%; height:100%; border-radius:50%">`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 383
+BEFORE: localStorage.removeItem(`hy_neural_session_id_\${claudeId}`);
+AFTER: localStorage.removeItem(`hy_neural_session_id_${claudeId}`);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 403
+BEFORE: addTel("SYSTEM", `Iniciando sesión - Source: "\${source}", Branch: "\${branch}"`, "info");
+AFTER: addTel("SYSTEM", `Iniciando sesión - Source: "${source}", Branch: "${branch}"`, "info");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 420
+BEFORE: prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-\${Date.now()}).`;
+AFTER: prompt += `\n\nIMPORTANTE: Crea y trabaja en una nueva rama dedicada para esta tarea (ej: jules/task-${Date.now()}).`;
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 443
+BEFORE: addTel("JULES", `Sesión iniciada: \${sid}`, "success");
+AFTER: addTel("JULES", `Sesión iniciada: ${sid}`, "success");
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 447
+BEFORE: localStorage.setItem(`hy_neural_session_id_\${claudeId}`, sid);
+AFTER: localStorage.setItem(`hy_neural_session_id_${claudeId}`, sid);
+---
+FILE: assets/javascript/jules-panel-auth.js
+LINE: 453
+BEFORE: const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural \${new Date().toLocaleDateString()}`;
+AFTER: const sessionName = taskContext.titulo || taskContext.title || `Sesión Neural ${new Date().toLocaleDateString()}`;
+---


### PR DESCRIPTION
I have repaired the three broken pages (Repo Admin, Neural Chat, and Jules Panel) that were failing after a major refactor. The root cause was a corruption of template literals in the 21 newly created JavaScript modules, where `${}` was incorrectly escaped as `\${}`. 

Additionally, I fixed structural issues in the Jekyll includes for CSS:
1. `_includes/repo-admin-styles.html`: Wrapped raw CSS in `<style>` tags and removed misplaced JavaScript.
2. `_includes/jules-panel-styles.html`: Removed redundant jQuery, Bootstrap, and UI component inclusions that were causing "Identifier 'UI' has already been declared" errors.

All pages are now loading correctly without console errors, as verified by automated Playwright tests and syntax audits.

---
*PR created automatically by Jules for task [1349981441729181878](https://jules.google.com/task/1349981441729181878) started by @Axlfc*