### PR TITLE
Fix Jules Panel API runtime errors after OAuth

### DIFF
--- a/assets/javascript/github-api-ops.js
+++ b/assets/javascript/github-api-ops.js
@@ -77,6 +77,53 @@
     // Export to window
     window.githubOps = githubOps;
 
+    // Extend window.githubApi if it exists, otherwise initialize it
+    window.githubApi = window.githubApi || {};
+    window.githubApi.getRepos = async () => {
+        const repos = await githubOps.fetchRepositories();
+        // Ensure the panel has the expected structure
+        return repos.map(r => ({
+            ...r,
+            owner: r.full_name.split('/')[0]
+        }));
+    };
+
+    window.githubApi.getBranches = async (repoFullName) => {
+        const parts = repoFullName.split('/');
+        const repo = parts.pop();
+        const owner = parts.length > 0 ? parts[0] : OPS_ORG;
+
+        const headers = githubOps.getHeaders();
+        const response = await fetch(`${GITHUB_OPS_BASE}/repos/${owner}/${repo}/branches?per_page=100`, {
+            headers
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ message: 'Unknown error' }));
+            throw new Error(`GitHub API Error: ${response.status} - ${error.message}`);
+        }
+
+        return await response.json();
+    };
+
+    window.githubApi.getRepo = async (repoFullName) => {
+        const parts = repoFullName.split('/');
+        const repo = parts.pop();
+        const owner = parts.length > 0 ? parts[0] : OPS_ORG;
+
+        const headers = githubOps.getHeaders();
+        const response = await fetch(`${GITHUB_OPS_BASE}/repos/${owner}/${repo}`, {
+            headers
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ message: 'Unknown error' }));
+            throw new Error(`GitHub API Error: ${response.status} - ${error.message}`);
+        }
+
+        return await response.json();
+    };
+
     /**
      * ATOMIC TASK MANAGEMENT (Bloque 2)
      */

--- a/assets/javascript/github-api.js
+++ b/assets/javascript/github-api.js
@@ -630,7 +630,7 @@ async function validateTokenAndStore() {
 }
 
 // ─── PUBLIC API ───────────────────────────────────────────────
-window.githubApi = {
+window.githubApi = Object.assign(window.githubApi || {}, {
   // Auth methods (compatibilidad con auth-manager.js)
   get user() { return _currentUser; },
   setToken(token, rememberMe = false) {
@@ -761,7 +761,7 @@ window.githubApi = {
   totalMonthlyExpenses,
   cumulativeProfitLoss,
   salesNeededBreakEven
-};
+});
 
 /**
  * LEGACY GitHubAPI class for backward compatibility with dashboard.md

--- a/assets/javascript/jules-api.js
+++ b/assets/javascript/jules-api.js
@@ -100,6 +100,15 @@ class JulesAPI {
         return await julesApiCall('GET', url);
     }
 
+    /**
+     * Alias for getSessions that returns only the sessions array.
+     * Expected by jules-panel-sessions.js
+     */
+    async listSessions(pageSize = 100) {
+        const data = await this.getSessions(pageSize);
+        return data.sessions || [];
+    }
+
     async createSession(data) {
         const res = await julesApiCall('POST', '/sessions', data);
         if (res && res.name && window.JulesActivitiesModule) {


### PR DESCRIPTION
Two runtime errors occurred in the Jules Panel due to missing methods on `window.githubApi` and `window.julesApi`. 

1. `window.githubApi.getRepos` was missing because it was defined in `githubContext` but not exposed on `githubApi`. I've now exposed `getRepos`, `getBranches`, and `getRepo` on `window.githubApi` within `github-api-ops.js`.
2. `window.julesApi.listSessions` was missing because the API client used `getSessions`. I've added `listSessions` as an alias that returns the sessions array directly.
3. To prevent race conditions and overwriting between `github-api.js` and `github-api-ops.js`, I've updated the initialization to use `Object.assign`.

Verified via Playwright script that all methods are correctly attached to the global window objects and that the panel loads without "is not a function" errors.

---
*PR created automatically by Jules for task [10101439298360708007](https://jules.google.com/task/10101439298360708007) started by @TopperH4rley*