### PR TITLE
Implement Missing Session Drawer Logic

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -97,6 +97,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul>
+              <li><strong>Drawer de Sesiones (Jules Panel):</strong> Implementadas las funciones <code>toggleSessionDrawer</code> y <code>renderSessionDrawerList</code>, solucionando el error <code>toggleSessionDrawer is not defined</code> y permitiendo la visualización y gestión del historial de sesiones locales.</li>
               <li><strong>Navegación de Documentación:</strong> Corregido el bug que impedía cargar archivos con espacios (ej: "00 - Inicio.md") desde el sidebar o mediante enlaces directos.</li>
               <li><strong>Resolución de Carpetas:</strong> Mejorada la lógica de <code>renderSidebar</code> para que los clics en carpetas resuelvan correctamente el archivo de índice más saludable.</li>
               <li><strong>Persistencia de Sesiones (Critical):</strong> Implementada la función <code>saveSessionsV2</code> en <code>jules-panel-neural.js</code>, resolviendo el <code>ReferenceError</code> que impedía la carga de datos y el guardado de mensajes en el panel.</li>

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -56,6 +56,83 @@ window.handleJulesApiError = function(e) {
     addTel("SYSTEM", "Error API: " + msg, "error");
 }
 
+window.toggleSessionDrawer = function() {
+    const drawer = $('sessions-drawer');
+    const overlay = $('sessions-drawer-overlay');
+    if (!drawer || !overlay) return;
+
+    const isOpen = drawer.classList.toggle('open');
+    overlay.classList.toggle('open');
+
+    if (isOpen) {
+        renderSessionDrawerList();
+    }
+}
+
+window.renderSessionDrawerList = function() {
+    const listContainer = $('sessions-drawer-list');
+    if (!listContainer) return;
+
+    let sessions = [];
+    try {
+        sessions = JSON.parse(localStorage.getItem('hy_neural_sessions') || '[]');
+    } catch (e) {
+        console.error("Error parsing hy_neural_sessions", e);
+    }
+
+    if (sessions.length === 0) {
+        listContainer.innerHTML = '<div style="text-align:center; padding:40px; color:var(--text3); font-size:13px;">No hay sesiones guardadas</div>';
+        return;
+    }
+
+    // Sort by date (newest first)
+    sessions.sort((a, b) => {
+        const dateA = new Date(a.createdAt || a.timestamp || 0);
+        const dateB = new Date(b.createdAt || b.timestamp || 0);
+        return dateB - dateA;
+    });
+
+    listContainer.innerHTML = sessions.map(function(s) {
+        const shortId = s.id ? s.id.substring(0, 8) : '--------';
+        let title = s.title;
+
+        if (!title && s.messages && s.messages.length > 0) {
+            const firstUserMsg = s.messages.find(function(m) { return m.role === 'user'; });
+            if (firstUserMsg && firstUserMsg.content) {
+                title = firstUserMsg.content.substring(0, 60);
+            }
+        }
+
+        if (!title) title = "Sin título";
+
+        const truncatedTitle = title.length > 40 ? title.substring(0, 40) + '…' : title;
+        const timeLabel = window.getTimeAgo ? window.getTimeAgo(s.createdAt || s.timestamp) : (s.createdAt || s.timestamp || '---');
+
+        return '<div class="session-drawer-item" onclick="selectSessionFromDrawer(\'' + s.id + '\')" style="padding:14px; border:1px solid var(--border); border-radius:var(--r-sm); cursor:pointer; transition:all 0.2s; background:var(--surface);">' +
+                '<div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:4px;">' +
+                    '<span style="font-family:var(--font-mono); font-size:10px; color:var(--accent2); font-weight:700;">#' + shortId + '</span>' +
+                    '<span style="font-size:10px; color:var(--text3);">' + timeLabel + '</span>' +
+                '</div>' +
+                '<div style="font-size:13px; font-weight:600; color:var(--text); line-height:1.4; word-break:break-word;">' + escapeHtml(truncatedTitle) + '</div>' +
+            '</div>';
+    }).join('');
+
+    // Add hover effects via JS if needed or rely on CSS if session-drawer-item is defined in styles
+}
+
+window.selectSessionFromDrawer = function(id) {
+    toggleSessionDrawer();
+    localStorage.setItem('hy_active_neural_session', id);
+
+    if (window.loadSession && typeof window.loadSession === 'function') {
+        window.loadSession(id);
+    } else {
+        const url = new URL('/chat/neural/', window.location.origin);
+        url.searchParams.set('session_id', id);
+        window.location.href = url.toString();
+    }
+}
+
 /**
  * Persiste los mensajes actuales de chatV2Messages en el almacenamiento local
  * vinculado a la sesión de Jules activa.


### PR DESCRIPTION
The `toggleSessionDrawer` function was missing, causing errors when trying to open the neural history drawer. I've implemented the missing logic in `assets/javascript/jules-panel-neural.js`, including the rendering of session cards with proper sorting, title fallbacks, and navigation handling.

---
*PR created automatically by Jules for task [11469214701714675930](https://jules.google.com/task/11469214701714675930) started by @TopperH4rley*