### PR TITLE
Unify Authentication and Decouple Authorization in Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -63,6 +63,12 @@ permalink: /CHANGELOG.html
         <h2 class="text-purple border-bottom border-purple pb-2 mb-4">[Unreleased]</h2>
         <div class="card mb-3">
           <div class="card-body">
+            <h5 class="text-success">Fixed</h5>
+            <ul>
+                <li><strong>Autenticación Unificada (Jules Panel):</strong> Corregido bug donde usuarios válidos aparecían como "Invitado". Se eliminó la dependencia de un allowlist hardcodeado en <code>github-api.js</code>, desacoplando la autenticación (validación del token) de la autorización (membresía de equipo).</li>
+                <li><strong>Single Source of Truth:</strong> Refactorizado <code>AuthManager</code> y el flujo de inicialización del panel para consumir un estado de usuario centralizado, eliminando condiciones de carrera y discrepancias entre módulos.</li>
+                <li><strong>Configuración API:</strong> Habilitado el acceso al modal de API Key para cualquier usuario autenticado, asegurando que el estado de login sea consistente en toda la interfaz.</li>
+            </ul>
             <h5 class="text-white">Added</h5>
             <ul>
                 <li><strong>Rediseño de Sidebar Neural:</strong> Implementado sidebar colapsable (48px/260px) con transiciones suaves, estado persistente en <code>localStorage</code> y tooltips contextuales para navegación rápida.</li>

--- a/assets/javascript/auth.js
+++ b/assets/javascript/auth.js
@@ -25,25 +25,25 @@ class AuthManager {
 
             try {
                 const result = await this.handleOAuthCallback();
-                if (result) {
+                if (result && result.valid) {
                     console.log('[AUTH] OAuth exchange successful via AuthManager');
                     this.dispatchAuthReady(result.user);
                     return;
                 }
             } catch (e) {
                 console.error('[AUTH] OAuth exchange failed in init:', e);
-                return;
+                // Continue to check existing state as fallback
             }
 
             console.log('[AUTH] No OAuth code or exchange completed. Checking existing session...');
-            await this.checkAuthState();
-            this.dispatchAuthReady(window.githubApi.user || null);
+            const user = await this.checkAuthState();
+            this.dispatchAuthReady(user);
             return;
         }
 
         await this.handleOAuthCallback();
-        await this.checkAuthState();
-        this.dispatchAuthReady(window.githubApi.user || null);
+        const user = await this.checkAuthState();
+        this.dispatchAuthReady(user);
     }
 
     dispatchAuthReady(user) {
@@ -121,12 +121,12 @@ class AuthManager {
                 if (result.valid) {
                     this.updateHeaderUI(result.user);
                     this.showToast('Éxito', 'Sesión iniciada correctamente.', 'success');
-                    return result; // Retornar resultado para coordinar con dashboard-data.js
+                    return result;
                 } else {
                     const err = {
-                        status: result.user ? 403 : 401,
-                        type: result.user ? 'ACL_DENIED' : 'INVALID',
-                        message: result.user ? 'Usuario no autorizado' : 'Token inválido'
+                        status: result.status || 401,
+                        type: 'INVALID',
+                        message: 'Fallo en la validación del token tras el intercambio.'
                     };
                     this.handleAuthError(err);
                     throw err;
@@ -135,17 +135,10 @@ class AuthManager {
                 console.error('[AUTH] Exchange failed:', e);
                 this.showToast('Error', 'Fallo en la autenticación OAuth: ' + (e.message || 'Error desconocido'), 'error');
 
-            // En páginas protegidas, simplemente limpiar y disparar authReady con null
-            // para que los gates locales tomen el control en lugar de redirigir al home.
-            window.githubApi.clearAuth();
-            document.dispatchEvent(new CustomEvent('authReady', {
-                detail: { user: null }
-            }));
-
+                // Clear auth and notify
+                window.githubApi.clearAuth();
+                this.dispatchAuthReady(null);
                 throw e;
-            } finally {
-                // No reseteamos _oauthExchanging para evitar que otros disparadores lo intenten de nuevo
-                // ya que el código ya fue consumido y la URL limpiada.
             }
         }
         return null;
@@ -155,14 +148,14 @@ class AuthManager {
         const token = window.githubApi.getAuthToken();
         if (!token) {
             this.updateHeaderUI(null);
-            return;
+            return null;
         }
 
         const lastAttempt = parseInt(sessionStorage.getItem('auth_last_attempt') || '0');
         const now = Date.now();
-        if (now - lastAttempt < 2000) {
+        if (now - lastAttempt < 1000) {
             console.warn('[AuthManager] Deteniendo posible bucle de redirección/validación.');
-            return;
+            return window.githubApi.user;
         }
         sessionStorage.setItem('auth_last_attempt', now.toString());
 
@@ -170,14 +163,17 @@ class AuthManager {
             const result = await window.githubApi.validateToken();
             if (result.valid) {
                 this.updateHeaderUI(result.user);
+                return result.user;
             } else {
                 this.handleAuthError({
-                    status: result.user ? 403 : 401,
-                    type: result.user ? 'ACL_DENIED' : 'INVALID'
+                    status: result.status || 401,
+                    type: 'INVALID'
                 });
+                return null;
             }
         } catch (e) {
             this.handleAuthError(e);
+            return null;
         }
     }
 
@@ -253,23 +249,18 @@ class AuthManager {
     }
 
     handleAuthError(e) {
-        if (e.status === 401 || (e.status === 403 && e.type === 'ACL_DENIED') || e.type === 'INVALID') {
+        if (e.status === 401 || e.type === 'INVALID') {
             window.githubApi.clearAuth();
             this.updateHeaderUI(null);
         }
 
         if (e.status === 403 && e.type === 'ACL_DENIED') {
-            const msgEl = document.getElementById('access-denied-message');
-            if (msgEl) msgEl.innerText = "Autenticado con éxito en GitHub, pero no tienes autorización explícita de la facción Hypenosys. Acceso revocado.";
-
-            if (window.jQuery && window.jQuery.fn.modal) {
-                window.jQuery('#settingsModal').modal('hide');
-                window.jQuery('#accessDeniedModal').modal('show');
-            }
+            // Keep the user authenticated but show restricted access if needed
+            // This is now handled at a layer above (e.g., showing a warning instead of locking)
+            this.showToast('Acceso Restringido', 'Estás autenticado pero no tienes permisos de equipo para ciertas operaciones de escritura.', 'warning');
 
             const dashUnauthorized = document.getElementById('unauthorized-overlay');
             if (dashUnauthorized) dashUnauthorized.classList.remove('hidden');
-
         } else if (e.status === 401 || e.type === 'INVALID') {
             this.showToast('Sesión Expirada', 'Tu token es inválido o ha caducado. Por favor, vuelve a iniciar sesión.', 'error');
             const loginOverlay = document.getElementById('login-overlay');
@@ -495,12 +486,13 @@ class AuthManager {
     }
 
     async showApiConfigModal() {
-        if (!window.githubApi.user) {
+        const user = window.githubApi.user;
+        if (!user) {
             this.showToast('Error', 'Debes estar autenticado para configurar la API.', 'error');
             return;
         }
 
-        const login = window.githubApi.user.login;
+        const login = user.login;
         let config = JSON.parse(localStorage.getItem('hy_ai_config') || '{}');
 
         // Fallback to team_profiles.json if localStorage is empty for provider/model

--- a/assets/javascript/github-api.js
+++ b/assets/javascript/github-api.js
@@ -34,12 +34,30 @@ async function validateToken() {
         'Accept': 'application/vnd.github.v3+json'
       }
     });
-    if (!resp.ok) return { valid: false, user: null };
+
+    if (!resp.ok) {
+        if (resp.status === 401) {
+            console.warn('[GITHUB-API] Token expired or invalid (401)');
+        }
+        return { valid: false, user: null, status: resp.status };
+    }
+
     const user = await resp.json();
+
+    // Auth check: Authentication is successful if GitHub returns a valid user
+    if (!user || !user.login) {
+        return { valid: false, user: null };
+    }
+
+    // Permission layer: Decoupled from authentication
     const ALLOWED = ['axlfc', 'mitxel2022', 'topperh4rley', 'dkdidac-design', 'javi26031994-a11y'];
-    return { valid: ALLOWED.includes(user.login.toLowerCase()), user };
+    user.isTeamMember = ALLOWED.includes(user.login.toLowerCase());
+
+    console.log(`[GITHUB-API] Authenticated as ${user.login} (Team: ${user.isTeamMember})`);
+    return { valid: true, user };
   } catch (err) {
-    return { valid: false, user: null };
+    console.error('[GITHUB-API] Validation error:', err);
+    return { valid: false, user: null, error: err.message };
   }
 }
 
@@ -630,9 +648,16 @@ async function validateTokenAndStore() {
 }
 
 // ─── PUBLIC API ───────────────────────────────────────────────
-window.githubApi = Object.assign(window.githubApi || {}, {
+window.githubApi = window.githubApi || {};
+Object.defineProperty(window.githubApi, 'user', {
+  get: function() { return _currentUser; },
+  set: function(val) { _currentUser = val; },
+  enumerable: true,
+  configurable: true
+});
+
+window.githubApi = Object.assign(window.githubApi, {
   // Auth methods (compatibilidad con auth-manager.js)
-  get user() { return _currentUser; },
   setToken(token, rememberMe = false) {
     if (!token) return;
     const cleanToken = token.trim();

--- a/assets/javascript/jules-panel-auth.js
+++ b/assets/javascript/jules-panel-auth.js
@@ -21,14 +21,35 @@ window.showAuthCard = function(id) {
 }
 
 window.initRealPanel = async function(user) {
-    if (!user && !getGitHubToken()) { showAuthCard("auth-card-login"); return; }
+    const token = getGitHubToken();
+    if (!user && !token) {
+        console.log("[JULES-AUTH] No user and no token. Showing login card.");
+        showAuthCard("auth-card-login");
+        return;
+    }
+
+    // If we have a token but no user object yet, try to validate it once
+    if (!user && token) {
+        console.log("[JULES-AUTH] Token present but no user. Validating...");
+        try {
+            const res = await window.githubApi.validateToken();
+            if (res.valid) {
+                user = res.user;
+            }
+        } catch (e) {
+            console.error("[JULES-AUTH] Pre-init validation failed:", e);
+        }
+    }
+
     $("auth-overlay").classList.remove("show");
     $("app-root").classList.remove("locked");
 
-    if (user) {
+    if (user && user.login) {
+        console.log("[JULES-AUTH] Initializing as user:", user.login);
         updateUserUI(user);
         addTel("SYSTEM", "Iniciado como " + user.login, "success");
     } else {
+        console.warn("[JULES-AUTH] Initializing as GUEST (no valid user resolved)");
         addTel("SYSTEM", "Iniciado como Invitado", "success");
     }
 
@@ -488,10 +509,11 @@ window.launchSession = async function() {
         localStorage.setItem('hy_neural_sessions', JSON.stringify(sessions));
 
         if (window.JulesPanelState.linkedTaskId) {
+            const currentUser = window.githubApi.user || user;
             await window.taskOps.updateTask(window.JulesPanelState.linkedTaskId, {
                 jules_session: {
                     session_id: sid,
-                    initiated_by: (window.githubApi.user && window.githubApi.user.login) || 'Invitado',
+                    initiated_by: (currentUser && currentUser.login) || 'Invitado',
                     status: 'PLANNING',
                     updated_at: new Date().toISOString()
                 }

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -937,10 +937,40 @@ permalink: /jules-panel/
 <script>
     async function init() {
         let arrancado = false;
-        window._bootJules = (user) => { if (arrancado) return; arrancado = true; initRealPanel(user); };
-        document.addEventListener("authReady", (e) => window._bootJules(e.detail?.user));
-        // Fix: Idempotent failsafe to avoid AuthManager collision (auth.js:164)
-        setTimeout(() => { if (!arrancado && !window.authManager) { if (getGitHubToken()) window._bootJules(window.githubApi?.user); else showAuthCard("auth-card-error"); } }, 5000);
+        window._bootJules = (user) => {
+            if (arrancado) {
+                console.log("[JULES-INIT] Already started, ignoring boot call.");
+                return;
+            }
+            arrancado = true;
+            initRealPanel(user);
+        };
+
+        // Listen for AuthManager readiness
+        document.addEventListener("authReady", (e) => {
+            const user = e.detail?.user;
+            console.log("[JULES-INIT] authReady received. User:", user?.login || 'guest');
+            window._bootJules(user);
+        });
+
+        // Failsafe: If AuthManager doesn't fire after 3 seconds, try to boot with what we have
+        setTimeout(() => {
+            if (!arrancado) {
+                console.log("[JULES-INIT] Failsafe triggered. Checking fallback state...");
+                const token = getGitHubToken();
+                const apiUser = window.githubApi?.user;
+
+                if (apiUser) {
+                    window._bootJules(apiUser);
+                } else if (token) {
+                    // We have a token but githubApi.user is not yet populated.
+                    // initRealPanel will handle the validation.
+                    window._bootJules(null);
+                } else {
+                    showAuthCard("auth-card-login");
+                }
+            }
+        }, 3000);
 
         document.querySelectorAll('.opt-pill').forEach(pill => {
             pill.onclick = () => {


### PR DESCRIPTION
This PR resolves the issue where authenticated GitHub users were being incorrectly treated as Guests in the Jules Agent Control Panel.

### Key Changes:
1.  **Authentication vs Authorization**: Refactored `validateToken` in `assets/javascript/github-api.js` to return `valid: true` for any valid GitHub session. The team membership check is now a separate property (`user.isTeamMember`) rather than a hard requirement for authentication.
2.  **Centralized State**: Refactored `AuthManager` in `assets/javascript/auth.js` to use `window.githubApi.user` as the single source of truth and eliminated discrepancies between modules.
3.  **Resilient Initialization**: Improved the boot logic in `pages/jules-panel.html` and `assets/javascript/jules-panel-auth.js` to correctly wait for authentication events and handle failsafes without defaulting to Guest mode prematurely.
4.  **Bug Fixes**:
    - Fixed the "Iniciado como Invitado" telemetry message for logged-in users.
    - Resolved the error "Debes estar autenticado para configurar la API" when clicking the API Key button while logged in.
5.  **Audit Logs**: Added clearer logging throughout the auth flow to aid future debugging without exposing sensitive tokens.

Verified with Playwright across Guest and Authenticated states.

---
*PR created automatically by Jules for task [3219340164972257605](https://jules.google.com/task/3219340164972257605) started by @TopperH4rley*