### PR TITLE
Fix Jules Task Launch Mode Validation

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul>
+                <li><strong>Validación de Lanzamiento (Jules Panel):</strong> Corregido el bloqueo que impedía iniciar tareas si solo se seleccionaba "Revisar Cambios". Ahora es posible lanzar sesiones en modo revisión sin requerir una sesión automática previa.</li>
                 <li><strong>Jules Panel Kanban:</strong> Corregido el fallo donde las tarjetas de sesión no se renderizaban a pesar de que los contadores se actualizaban. Se unificó el flujo de renderizado y se implementó un mapeo de estados robusto (<code>normalizeJulesStatus</code>), asegurando que los contadores coincidan con las tarjetas visibles.</li>
                 <li><strong>Filtro de Usuario:</strong> Las sesiones ahora se filtran correctamente por el login del usuario autenticado (<code>window.githubApi.user.login</code>), asegurando una vista personalizada del tablero.</li>
                 <li><strong>Persistencia de Kanban:</strong> Implementado sistema de overrides locales para permitir el drag & drop de sesiones entre columnas, persistiendo el estado visual mediante <code>localStorage</code> con badges indicadores.</li>
@@ -149,6 +150,8 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Changed</h5>
             <ul>
+              <li><strong>Modo por Defecto (Jules Panel):</strong> "Revisar Cambios" es ahora el modo de ejecución predeterminado al cargar el panel, promoviendo flujos de trabajo más seguros.</li>
+              <li><strong>Validación de Modos de Ejecución:</strong> Implementada validación obligatoria de al menos un modo (Automático o Revisión) antes del lanzamiento, con mensajes de error claros y telemetría detallada del payload.</li>
               <li><strong>Limpieza de UI Redundante:</strong> Eliminado el botón "USAR COMO PROMPT" del chat integrado en el Panel Jules, ya que el nuevo flujo de handoff automatizado lo hace innecesario.</li>
               <li><strong>Respuestas de Jules en Chat:</strong> Jules ahora responde directamente con burbujas en el flujo de conversación del Neural Chat mediante un sistema de polling de actividades que detecta eventos <code>agentMessaged</code>.</li>
               <li><strong>Unificación de Lectura de Datos:</strong> Migrada toda la lógica de lectura de perfiles y equipo para usar <code>fetch()</code> nativo, simplificando el código y eliminando peticiones innecesarias a la API de GitHub para datos públicos.</li>

--- a/assets/javascript/jules-panel-auth.js
+++ b/assets/javascript/jules-panel-auth.js
@@ -482,8 +482,12 @@ window.launchSession = async function() {
         return;
     }
 
-    if ($('opt-review').classList.contains('active') && !getLinkedJulesSessionId()) {
-        showToast("Selecciona primero Modo Automático para iniciar una nueva sesión", "red");
+    // Capture current UI mode
+    const isAuto = $('opt-auto').classList.contains('active');
+    const isReview = $('opt-review').classList.contains('active');
+
+    if (!isAuto && !isReview) {
+        showToast("Selecciona un modo de ejecución para iniciar la sesión.", "red");
         return;
     }
 
@@ -502,14 +506,29 @@ window.launchSession = async function() {
     btn.innerHTML = 'Iniciando...';
 
     try {
-        const body = { prompt, sourceContext: { source, githubRepoContext: { startingBranch: branch } } };
+        const body = {
+            prompt,
+            sourceContext: { source, githubRepoContext: { startingBranch: branch } },
+            autoMode: isAuto,
+            reviewChanges: isReview,
+            requirePlanApproval: isReview
+        };
 
-        if ($('opt-auto').classList.contains('active')) {
-            body.requirePlanApproval = false;
+        if (isAuto) {
             body.automationMode = "AUTO_CREATE_PR";
-        } else if ($('opt-review').classList.contains('active')) {
-            body.requirePlanApproval = true;
         }
+
+        // Defensive Logging
+        const logPayload = {
+            selectedMode: isAuto ? "auto" : "review",
+            autoMode: body.autoMode,
+            requirePlanApproval: body.requirePlanApproval,
+            reviewChanges: body.reviewChanges,
+            repo: source,
+            branch: branch
+        };
+        console.log("[Jules Launch] Payload:", logPayload);
+        addTel("SYSTEM", "Payload de lanzamiento: " + JSON.stringify(logPayload), "info");
 
         const res = await window.julesApi.createSession(body);
         const sid = res.name.split('/').pop();

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -317,11 +317,11 @@ permalink: /jules-panel/
           </div>
           <textarea class="prompt-area" id="session-prompt" placeholder="¿Qué debe hacer Jules?&#10;&#10;Ej: Refactoriza el componente Header para que sea responsive, usa variables HSL en index.css y añade un menú hamburguesa con animación suave..."></textarea>
           <div class="opts-grid">
-            <div class="opt-pill active" id="opt-auto">
+            <div class="opt-pill" id="opt-auto">
               <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
               Modo Automático
             </div>
-            <div class="opt-pill" id="opt-review">
+            <div class="opt-pill active" id="opt-review">
               <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
               Revisar Cambios
             </div>


### PR DESCRIPTION
This PR fixes the validation logic in the Jules Agent Control Panel that was previously blocking task execution unless "Modo Automático" was selected. 

The changes include:
1.  **Default Mode Change**: "Revisar Cambios" (Review Changes) is now the default safe mode when the panel loads.
2.  **Flexible Validation**: Tasks can now be launched with only "Revisar Cambios" selected. The code no longer requires a pre-existing session ID for this mode.
3.  **Correct Payload Generation**: The final payload sent to the Jules API now accurately reflects the user's choice:
    - If "Review Changes" is selected: `requirePlanApproval: true`, `reviewChanges: true`, `autoMode: false`.
    - If "Automatic Mode" is selected: `requirePlanApproval: false`, `autoMode: true`, and includes `automationMode: "AUTO_CREATE_PR"`.
4.  **Improved Error Messaging**: If no mode is selected, the user is prompted with "Selecciona un modo de ejecución para iniciar la sesión."
5.  **Logging**: Added telemetry and console logs to verify the payload before transmission.

These changes ensure that Jules can be used as a "safe-by-default" assistant while still allowing full automation when explicitly requested. No regressions were found in repo/branch selection or existing automatic mode functionality.

---
*PR created automatically by Jules for task [12750690704310490766](https://jules.google.com/task/12750690704310490766) started by @TopperH4rley*