### PR TITLE
Standalone Neural Interface for Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul>
+                <li><strong>Independencia del Jules Panel (Neural):</strong> El panel de control ahora funciona de forma totalmente independiente en el primer arranque. Se ha desacoplado de las variables globales del chat de Claude mediante un nuevo cliente de IA (<code>NeuralProviderClient</code>) que reutiliza la configuración de API existente y soporta streaming y persistencia local propia.</li>
                 <li><strong>Validación de Lanzamiento (Jules Panel):</strong> Corregido el bloqueo que impedía iniciar tareas si solo se seleccionaba "Revisar Cambios". Ahora es posible lanzar sesiones en modo revisión sin requerir una sesión automática previa.</li>
                 <li><strong>Jules Panel Kanban:</strong> Corregido el fallo donde las tarjetas de sesión no se renderizaban a pesar de que los contadores se actualizaban. Se unificó el flujo de renderizado y se implementó un mapeo de estados robusto (<code>normalizeJulesStatus</code>), asegurando que los contadores coincidan con las tarjetas visibles.</li>
                 <li><strong>Filtro de Usuario:</strong> Las sesiones ahora se filtran correctamente por el login del usuario autenticado (<code>window.githubApi.user.login</code>), asegurando una vista personalizada del tablero.</li>

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -2,6 +2,33 @@
    JULES PANEL NEURAL & CHAT MODULE
    ════════════════════════════════════════ */
 
+// Initialize V2 Messages from local persistence or empty array
+window.chatV2Messages = (function() {
+    try {
+        return JSON.parse(localStorage.getItem('hy_jules_panel_ai_messages') || '[]');
+    } catch (e) {
+        console.error("[JulesPanel Neural] Error loading local messages:", e);
+        return [];
+    }
+})();
+
+function saveLocalV2Messages() {
+    try {
+        localStorage.setItem('hy_jules_panel_ai_messages', JSON.stringify(window.chatV2Messages));
+    } catch (e) {
+        console.error("[JulesPanel Neural] Error saving local messages:", e);
+    }
+}
+
+window.loadV2Messages = function() {
+    try {
+        window.chatV2Messages = JSON.parse(localStorage.getItem('hy_jules_panel_ai_messages') || '[]');
+    } catch (e) {
+        console.error("[JulesPanel Neural] Error loading local messages:", e);
+        window.chatV2Messages = [];
+    }
+}
+
 // Mock logic for chat interactions
 window.sendNeuralMessage = async function() {
     const input = $('v2-chat-input');
@@ -76,6 +103,8 @@ function _renderLocalMessagesOnly() {
               '</button>' +
             '</div>' : '';
 
+        const renderedContent = isClaude && window.marked ? marked.parse(msg.content) : escapeHtml(msg.content);
+
         div.innerHTML =
             '<span class="activity-icon">' + icon + '</span>' +
             '<div class="activity-body">' +
@@ -83,7 +112,7 @@ function _renderLocalMessagesOnly() {
                 '<span class="activity-originator">' + (isClaude ? 'CLAUDE' : 'USUARIO') + '</span>' +
                 '<span class="activity-time">' + time + '</span>' +
               '</div>' +
-              '<div class="activity-content">' + escapeHtml(msg.content) + '</div>' +
+              '<div class="activity-content">' + renderedContent + '</div>' +
               actionBtn +
             '</div>';
 
@@ -175,17 +204,78 @@ window.sendChatV2Msg = async function() {
     if (window.currentSendMode === 'jules') {
         await window.sendNeuralMessage();
     } else {
-        // Claude mode: logic should be implemented in neural-chat-send.js
-        // but if we are in jules-panel we might need a bridge
-        if (window.sendMessage && typeof window.sendMessage === 'function') {
-            await window.sendMessage();
-        } else {
-            // Fallback for jules-panel
-            window.chatV2Messages.push({ role: 'user', content: msg });
-            input.value = '';
-            renderChatV2Messages();
-            addTel("USER", "Enviado a Claude (Simulado)", "info");
+        // AI/Claude mode for Jules Panel
+        input.value = '';
+        if (input.style) input.style.height = 'auto';
+
+        const userMsg = { role: 'user', content: msg, timestamp: Date.now() };
+        window.chatV2Messages.push(userMsg);
+        saveLocalV2Messages();
+        renderChatV2Messages();
+
+        const thinkingIndicator = $('v2-thinking-indicator');
+        if (thinkingIndicator) thinkingIndicator.classList.remove('hidden');
+
+        // Create placeholder for assistant message
+        const assistantMsg = { role: 'assistant', content: '', timestamp: Date.now() };
+        window.chatV2Messages.push(assistantMsg);
+        const assistantIdx = window.chatV2Messages.length - 1;
+
+        try {
+            const messages = window.chatV2Messages.slice(0, -1).map(function(m) { return { role: m.role, content: m.content }; });
+            await window.NeuralProviderClient.sendMessage({
+                messages: messages,
+                onToken: function(token, fullContent) {
+                    window.chatV2Messages[assistantIdx].content = fullContent;
+                    updateLocalAssistantMessage(assistantIdx, fullContent);
+                },
+                onDone: function(fullContent) {
+                    window.chatV2Messages[assistantIdx].content = fullContent;
+                    saveLocalV2Messages();
+                    if (thinkingIndicator) thinkingIndicator.classList.add('hidden');
+                },
+                onError: function(err) {
+                    console.error("[JulesPanel AI] Error:", err);
+                    if (thinkingIndicator) thinkingIndicator.classList.add('hidden');
+                    showToast(err.message, "red");
+
+                    // Remove the empty assistant placeholder on error if it has no content
+                    if (!window.chatV2Messages[assistantIdx].content) {
+                        window.chatV2Messages.splice(assistantIdx, 1);
+                        renderChatV2Messages();
+                    }
+                }
+            });
+        } catch (e) {
+            console.error("[JulesPanel AI] Unexpected error:", e);
+            if (thinkingIndicator) thinkingIndicator.classList.add('hidden');
+            showToast("Error inesperado: " + e.message, "red");
         }
+    }
+}
+
+function updateLocalAssistantMessage(idx, content) {
+    const container = $('v2-chat-messages');
+    if (!container) return;
+
+    const localId = 'local-' + idx;
+    let entry = container.querySelector('[data-id="' + localId + '"]');
+
+    if (!entry) {
+        renderChatV2Messages();
+        entry = container.querySelector('[data-id="' + localId + '"]');
+    }
+
+    if (entry) {
+        const contentEl = entry.querySelector('.activity-content');
+        if (contentEl) {
+            if (window.marked) {
+                contentEl.innerHTML = marked.parse(content);
+            } else {
+                contentEl.innerText = content;
+            }
+        }
+        container.scrollTop = container.scrollHeight;
     }
 }
 

--- a/assets/javascript/neural-provider-client.js
+++ b/assets/javascript/neural-provider-client.js
@@ -1,0 +1,145 @@
+/**
+ * Neural Provider Client
+ * DOM-independent client for AI provider interactions.
+ * Reuses existing API Config from localStorage: hy_ai_config.
+ */
+
+window.NeuralProviderClient = (function() {
+
+    function getConfig() {
+        try {
+            return JSON.parse(localStorage.getItem('hy_ai_config') || '{}');
+        } catch (e) {
+            console.error('[NeuralProviderClient] Error parsing hy_ai_config:', e);
+            return {};
+        }
+    }
+
+    function normalizeBaseUrl(url, provider) {
+        if (!url) return '';
+        let normalized = url.trim().replace(/\/+$/, '');
+
+        if (provider === 'ollama') {
+            if (!normalized.startsWith('http')) {
+                normalized = 'http://' + normalized;
+            }
+            if (!normalized.endsWith('/v1')) {
+                normalized += '/v1';
+            }
+        }
+        return normalized;
+    }
+
+    async function sendMessage({ messages, systemPrompt, onToken, onDone, onError }) {
+        const config = getConfig();
+        const provider = config.provider || 'none';
+
+        if (provider === 'none') {
+            const err = 'No hay proveedor de IA configurado. Por favor, usa el botón "API Config" para configurar Ollama o un endpoint compatible.';
+            if (onError) onError(new Error(err));
+            return;
+        }
+
+        const baseUrl = normalizeBaseUrl(config.base_url, provider);
+        const model = config.model || (provider === 'ollama' ? 'llama3' : 'gpt-3.5-turbo');
+        const apiKey = config.api_key || '';
+
+        console.log(`[NeuralProviderClient] Request started. Provider: ${provider}, Model: ${model}, BaseURL: ${baseUrl}`);
+
+        try {
+            const fullMessages = [];
+            if (systemPrompt) {
+                fullMessages.push({ role: 'system', content: systemPrompt });
+            }
+            fullMessages.push(...messages);
+
+            const endpoint = `${baseUrl}/chat/completions`;
+
+            const headers = {
+                'Content-Type': 'application/json'
+            };
+            if (apiKey) {
+                headers['Authorization'] = `Bearer ${apiKey}`;
+            }
+
+            // Specific check for NVIDIA NIM as seen in neural-chat-send.js
+            const isNIM = (config.base_url || '').includes('nvidia.com') ||
+                          (config.model || '').startsWith('nvidia/') ||
+                          (config.model || '').startsWith('meta/') ||
+                          (config.model || '').startsWith('mistralai/');
+            if (isNIM) {
+                headers['x-requested-with'] = 'XMLHttpRequest';
+            }
+
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: headers,
+                body: JSON.stringify({
+                    model: model,
+                    messages: fullMessages,
+                    stream: true
+                }),
+                mode: 'cors',
+                credentials: 'omit'
+            });
+
+            if (!response.ok) {
+                const errText = await response.text().catch(() => 'Unknown error');
+                throw new Error(`AI request failed for provider ${provider} at ${baseUrl}. Status: ${response.status}. ${errText}`);
+            }
+
+            console.log('[NeuralProviderClient] Stream started');
+
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let aiContent = '';
+            let buffer = '';
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                const chunk = decoder.decode(value, { stream: true });
+                buffer += chunk;
+                const lines = buffer.split('\n');
+                buffer = lines.pop();
+
+                for (const line of lines) {
+                    const trimmedLine = line.trim();
+                    if (!trimmedLine || !trimmedLine.startsWith('data: ')) continue;
+
+                    const dataStr = trimmedLine.substring(6);
+                    if (dataStr === '[DONE]') break;
+
+                    try {
+                        const data = JSON.parse(dataStr);
+                        const delta = data.choices?.[0]?.delta?.content || '';
+                        if (delta) {
+                            aiContent += delta;
+                            if (onToken) onToken(delta, aiContent);
+                        }
+                    } catch (e) {
+                        console.warn('[NeuralProviderClient] JSON parse error in stream:', e);
+                    }
+                }
+            }
+
+            console.log('[NeuralProviderClient] Done');
+            if (onDone) onDone(aiContent);
+
+        } catch (e) {
+            console.error('[NeuralProviderClient] Error:', e);
+            if (onError) {
+                // Ensure base_url is included in the error for diagnostics as requested
+                const detailedError = new Error(`AI request failed for provider ${provider} at ${baseUrl}. ${e.message}. Check VPN reachability, CORS/OLLAMA_ORIGINS and browser Mixed Content settings.`);
+                onError(detailedError);
+            }
+        }
+    }
+
+    return {
+        sendMessage,
+        normalizeBaseUrl
+    };
+
+})();

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -929,6 +929,7 @@ permalink: /jules-panel/
 <script src="{{ '/assets/javascript/jules-panel-metrics.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/jules-panel-kanban.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/jules-panel-hub.js' | relative_url }}"></script>
+<script src="{{ '/assets/javascript/neural-provider-client.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/jules-panel-neural.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/jules-panel-auth.js' | relative_url }}"></script>
 


### PR DESCRIPTION
The /jules-panel/ Neural interface was previously dependent on globals initialized by the /chat/neural/ page, preventing it from working correctly on first load. This change introduces a standalone `NeuralProviderClient` that handles all AI interactions independently while reusing the existing API Config from localStorage. 

Key improvements:
- **Standalone Client:** `NeuralProviderClient` provides a clean interface for `sendMessage` with streaming support.
- **Normalization:** Automatically normalizes base URLs, including ensuring `/v1` for Ollama and preserving VPN/IP endpoints.
- **Decoupling:** Removed all references to `/chat/neural/` specific globals (`window.sendMessage`, `window.chatMessages`, etc.) in the panel.
- **Persistence:** Panel-specific chat history is now persisted in `hy_jules_panel_ai_messages`.
- **UI Responsiveness:** Real streaming tokens are now rendered in the panel's chat view.
- **Diagnostics:** Error messages now include the provider and base URL to assist with debugging network connectivity issues (VPN, CORS, Mixed Content).

Frontend verification was performed using a Playwright script that confirmed the standalone behavior and streaming updates in the Jules Panel.

---
*PR created automatically by Jules for task [2874871605022924450](https://jules.google.com/task/2874871605022924450) started by @TopperH4rley*