### PR TITLE
Fix Neural Sessions Drawer Layout in Jules Panel

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -86,6 +86,7 @@ permalink: /CHANGELOG.html
                 <li><strong>Autenticación Unificada (Jules Panel):</strong> Corregido bug donde usuarios válidos aparecían como "Invitado". Se eliminó la dependencia de un allowlist hardcodeado en <code>github-api.js</code>, desacoplando la autenticación (validación del token) de la autorización (membresía de equipo).</li>
                 <li><strong>Single Source of Truth:</strong> Refactorizado <code>AuthManager</code> y el flujo de inicialización del panel para consumir un estado de usuario centralizado, eliminando condiciones de carrera y discrepancias entre módulos.</li>
                 <li><strong>Configuración API:</strong> Habilitado el acceso al modal de API Key para cualquier usuario autenticado, asegurando que el estado de login sea consistente en toda la interfaz.</li>
+                <li><strong>Layout del Historial Neural (Jules Panel):</strong> Corregido el problema visual donde el drawer de sesiones guardadas aparecía como un bloque de contenido al final de la página. Se añadieron los estilos CSS necesarios para que funcione correctamente como un panel lateral oculto por defecto.</li>
             </ul>
             <h5 class="text-white">Added</h5>
             <ul>

--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -1144,5 +1144,62 @@ body{
   box-shadow: 0 0 12px rgba(124, 58, 237, 0.2);
 }
 
+/* NEURAL SESSIONS DRAWER */
+.neural-drawer {
+  position: fixed;
+  top: 0;
+  right: -400px;
+  width: 400px;
+  height: 100%;
+  background: var(--surface-opaque);
+  border-left: 1px solid var(--border-accent);
+  box-shadow: -10px 0 40px rgba(0,0,0,0.8);
+  z-index: 1001;
+  display: flex;
+  flex-direction: column;
+  transition: right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.neural-drawer.open {
+  right: 0;
+}
+.neural-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+.neural-drawer-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+.neural-drawer-header {
+  padding: 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(0,0,0,0.2);
+}
+.session-drawer-item:hover {
+  background: var(--surface-hover) !important;
+  border-color: var(--accent) !important;
+}
+.session-drawer-item.active {
+  background: var(--surface-active) !important;
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 15px rgba(124, 58, 237, 0.1);
+}
+
+@media (max-width: 768px) {
+  .neural-drawer {
+    width: 100%;
+    right: -100%;
+  }
+}
+
 /* CLAUDE CHAT MODAL */
 </style>


### PR DESCRIPTION
Fixed the layout issue in Jules Panel where the Neural History drawer was appearing as a visible block at the bottom of the page. By adding the missing CSS for .neural-drawer and .neural-drawer-overlay in _includes/jules-panel-styles.html, the drawer now correctly functions as a hidden, fixed side panel. This change is scoped to the Jules Panel and does not affect the standalone neural chat page.

---
*PR created automatically by Jules for task [11781247803618543730](https://jules.google.com/task/11781247803618543730) started by @TopperH4rley*