### PR TITLE
Add Jules Panel Neural Chat History section

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Added</h5>
             <ul>
+                <li><strong>Neural Chat History (Jules Panel):</strong> Implementada una nueva sección en la sidebar del Panel Jules llamada <code>NEURAL CHAT HISTORY</code>. Permite gestionar hilos de conversación con Claude de forma independiente a las tareas de Jules, con soporte para navegación entre sesiones, creación de nuevos chats y borrado con confirmación.</li>
                 <li><strong>Mejora de UX Móvil en Generadores:</strong> Rediseño de las interfaces de síntesis visual y sonora para dispositivos móviles. Implementado sistema de paneles laterales colapsables con backdrop, navegación optimizada para touch, scroll horizontal en selectores de modo y optimización de rendimiento en visualizadores de audio.</li>
                 <li><strong>Persistencia en Generadores (IndexedDB):</strong> Implementado sistema de almacenamiento robusto para imágenes y música generadas utilizando IndexedDB. Esto permite mantener un historial extenso de archivos binarios (Blobs) sin saturar el almacenamiento del navegador.</li>
                 <li><strong>Auto-guardado de borradores:</strong> Los formularios de prompts y parámetros de síntesis ahora se guardan automáticamente como borradores en el almacenamiento local, evitando la pérdida de trabajo al refrescar la página.</li>

--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -460,6 +460,76 @@ body{
   margin-top: 4px;
 }
 
+/* ─── CHAT HISTORY ─── */
+.chat-history-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 11px;
+  border-radius: var(--r-sm);
+  color: var(--text2);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: var(--t-fast);
+  margin-bottom: 2px;
+  position: relative;
+}
+.chat-history-item:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+.chat-history-item.active {
+  background: rgba(124, 58, 237, 0.1);
+  color: var(--text);
+  border-left: 2px solid var(--accent);
+  font-weight: 500;
+}
+.chat-history-item .chat-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--border2);
+  flex-shrink: 0;
+}
+.chat-history-item.active .chat-dot {
+  background: var(--accent);
+  box-shadow: 0 0 7px var(--accent);
+}
+.chat-history-item .chat-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-history-item .btn-delete-session {
+  opacity: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: var(--text3);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.chat-history-item:hover .btn-delete-session {
+  opacity: 1;
+}
+.chat-history-item .btn-delete-session:hover {
+  color: var(--red);
+  background: var(--red-soft);
+}
+/* Mobile compatibility for delete button */
+@media (max-width: 1024px) {
+  .chat-history-item .btn-delete-session {
+    opacity: 0.6;
+  }
+}
+
 /* ─── SKELETON LOADING ─── */
 @keyframes shimmer {
   0% { background-position: -200% 0; }

--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -134,6 +134,7 @@ body{
 .sidebar.collapsed .user-name,
 .sidebar.collapsed .user-online,
 .sidebar.collapsed .sb-history-item,
+  .sidebar.collapsed .chat-history-item,
 .sidebar.collapsed .nav-link:not(:has(svg)),
 .sidebar.collapsed .sb-footer div:last-child {
   display: none !important;

--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -461,6 +461,11 @@ body{
 }
 
 /* ─── CHAT HISTORY ─── */
+#ng-chat-history {
+  border-top: 1px solid var(--border);
+  padding-top: 15px;
+  margin-top: 5px;
+}
 .chat-history-item {
   display: flex;
   align-items: center;

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -16,13 +16,17 @@ function saveJulesPanelSessions() {
 window.loadJulesPanelSessions = function() {
     window.julesPanelSessions = window.NeuralChatCore.getSessions(window.JULES_PANEL_NEURAL_STORAGE);
     window.currentJulesPanelSessionId = localStorage.getItem(window.JULES_PANEL_NEURAL_ACTIVE_ID);
+    window.renderNeuralChatHistory();
 }
 
 /**
  * Initialize Neural Chat for Jules Panel
  */
 window.initJulesPanelNeuralChat = function() {
-    if (window._julesPanelNeuralInitialized) return;
+    if (window._julesPanelNeuralInitialized) {
+        window.renderNeuralChatHistory();
+        return;
+    }
     console.log("[Jules Panel Neural] Initializing...");
 
     window.loadJulesPanelSessions();
@@ -66,9 +70,11 @@ window.initJulesPanelNeuralChat = function() {
     });
 
     window.addEventListener('storage', (e) => {
-        if (e.key === window.JULES_PANEL_NEURAL_STORAGE && $('sessions-drawer')?.classList.contains('open')) {
+        if (e.key === window.JULES_PANEL_NEURAL_STORAGE) {
             window.loadJulesPanelSessions();
-            window.renderJulesPanelSessionDrawerList();
+            if ($('sessions-drawer')?.classList.contains('open')) {
+                window.renderJulesPanelSessionDrawerList();
+            }
         }
     });
 
@@ -120,6 +126,7 @@ window.createNewJulesPanelSession = function() {
     window.julesPanelSessions.unshift(newSession);
     saveJulesPanelSessions();
     window.loadJulesPanelSession(newSession.id);
+    window.renderNeuralChatHistory();
 }
 
 window.loadJulesPanelSession = function(id) {
@@ -130,6 +137,7 @@ window.loadJulesPanelSession = function(id) {
     if (!session) return;
 
     window.renderChatV2Messages();
+    window.renderNeuralChatHistory();
 }
 
 window.sendChatV2Msg = async function() {
@@ -160,13 +168,17 @@ window.sendChatV2Msg = async function() {
     await window.NeuralChatCore.sendMessage({
         session: session,
         userMessage: msg,
-        saveCallback: saveJulesPanelSessions,
+        saveCallback: () => {
+            saveJulesPanelSessions();
+            window.renderNeuralChatHistory();
+        },
         onToken: () => {
             window.renderChatV2Messages();
         },
         onDone: () => {
             if (thinkingIndicator) thinkingIndicator.classList.add('hidden');
             window.renderChatV2Messages();
+            window.renderNeuralChatHistory();
         },
         onError: (err) => {
             if (thinkingIndicator) thinkingIndicator.classList.add('hidden');
@@ -174,6 +186,41 @@ window.sendChatV2Msg = async function() {
             window.renderChatV2Messages();
         }
     });
+}
+
+window.renderNeuralChatHistory = function() {
+    const container = $('chat-history-list');
+    if (!container) return;
+
+    const sessions = (window.julesPanelSessions || []).filter(s => !s.archived);
+
+    if (sessions.length === 0) {
+        container.innerHTML = '<div class="notif-empty" style="font-size: 10px; padding: 10px;">Sin historial de chat</div>';
+        return;
+    }
+
+    container.innerHTML = sessions.map(function(s) {
+        const isActive = s.id === window.currentJulesPanelSessionId;
+
+        // Title logic: title -> first user message -> "Nueva conversación"
+        let displayTitle = s.title;
+        if (!displayTitle || displayTitle === 'Nueva Conversación') {
+            const firstUserMsg = s.messages.find(m => m.role === 'user');
+            if (firstUserMsg) {
+                displayTitle = firstUserMsg.content.substring(0, 40) + (firstUserMsg.content.length > 40 ? '...' : '');
+            } else {
+                displayTitle = 'Nueva conversación';
+            }
+        }
+
+        return '<div class="chat-history-item' + (isActive ? ' active' : '') + '" onclick="window.loadJulesPanelSession(\'' + s.id + '\')">' +
+                 '<div class="chat-dot"></div>' +
+                 '<div class="chat-title" title="' + window.NeuralChatCore.escapeHtml(displayTitle) + '">' + window.NeuralChatCore.escapeHtml(displayTitle) + '</div>' +
+                 '<button class="btn-delete-session" onclick="window.deleteJulesPanelSession(event, \'' + s.id + '\')" title="Borrar">' +
+                   '<i class="fas fa-trash"></i>' +
+                 '</button>' +
+               '</div>';
+    }).join('');
 }
 
 window.renderChatV2Messages = function() {
@@ -474,6 +521,9 @@ window.archiveJulesPanelSession = function(event, id) {
 window.deleteJulesPanelSession = function(event, id) {
     if (event) event.stopPropagation();
 
+    const session = window.julesPanelSessions.find(s => s.id === id);
+    const sessionTitle = session ? session.title : 'esta sesión';
+
     const performDelete = () => {
         const index = window.julesPanelSessions.findIndex(s => s.id === id);
         if (index === -1) return;
@@ -491,12 +541,15 @@ window.deleteJulesPanelSession = function(event, id) {
         }
 
         window.renderJulesPanelSessionDrawerList();
+        window.renderNeuralChatHistory();
         showToast("Sesión eliminada", "red");
     };
 
+    const confirmMsg = "¿Seguro que quieres borrar la sesión \"" + sessionTitle + "\"? Esta acción no se puede deshacer.";
+
     if (window.showConfirmationToast) {
-        window.showConfirmationToast("¿Seguro que quieres borrar esta sesión? Esta acción no se puede deshacer.", performDelete);
-    } else if (window.confirm("¿Seguro que quieres borrar esta sesión? Esta acción no se puede deshacer.")) {
+        window.showConfirmationToast(confirmMsg, performDelete);
+    } else if (window.confirm(confirmMsg)) {
         performDelete();
     }
 }

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -204,7 +204,7 @@ window.renderNeuralChatHistory = function() {
 
         // Title logic: title -> first user message -> "Nueva conversación"
         let displayTitle = s.title;
-        if (!displayTitle || displayTitle === 'Nueva Conversación') {
+        if (!displayTitle || displayTitle.toLowerCase() === 'nueva conversación') {
             const firstUserMsg = s.messages.find(m => m.role === 'user');
             if (firstUserMsg) {
                 displayTitle = firstUserMsg.content.substring(0, 40) + (firstUserMsg.content.length > 40 ? '...' : '');

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -141,7 +141,7 @@ permalink: /jules-panel/
       </a>
     </div>
 
-    <div class="nav-group" id="ng-repos" style="flex:1;display:flex;flex-direction:column">
+    <div class="nav-group" id="ng-repos">
       <div class="nav-label" onclick="toggleNavGroup('ng-repos')">
         <span>Repositorios</span>
         <i class="fas fa-chevron-down"></i>
@@ -149,7 +149,7 @@ permalink: /jules-panel/
       <div class="sb-repos" id="repo-list"></div>
     </div>
 
-    <div class="nav-group" id="ng-chat-history" style="display:flex;flex-direction:column; border-top: 1px solid var(--border); padding-top: 15px;">
+    <div class="nav-group" id="ng-chat-history">
       <div class="nav-label" onclick="toggleNavGroup('ng-chat-history')">
         <span>Neural Chat History</span>
         <i class="fas fa-chevron-down"></i>

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -151,7 +151,7 @@ permalink: /jules-panel/
 
     <div class="nav-group" id="ng-chat-history">
       <div class="nav-label" onclick="toggleNavGroup('ng-chat-history')">
-        <span>Neural Chat History</span>
+        <span>NEURAL CHAT HISTORY</span>
         <i class="fas fa-chevron-down"></i>
       </div>
       <div class="sb-repos" id="chat-history-list">

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -149,6 +149,16 @@ permalink: /jules-panel/
       <div class="sb-repos" id="repo-list"></div>
     </div>
 
+    <div class="nav-group" id="ng-chat-history" style="display:flex;flex-direction:column; border-top: 1px solid var(--border); padding-top: 15px;">
+      <div class="nav-label" onclick="toggleNavGroup('ng-chat-history')">
+        <span>Neural Chat History</span>
+        <i class="fas fa-chevron-down"></i>
+      </div>
+      <div class="sb-repos" id="chat-history-list">
+        <div class="notif-empty" style="font-size: 10px; padding: 10px;">Cargando historial...</div>
+      </div>
+    </div>
+
   </aside>
 
   <!-- ══ MAIN ══ -->


### PR DESCRIPTION
This PR adds a new 'NEURAL CHAT HISTORY' section to the Jules Panel sidebar, allowing users to manage chat sessions with Claude independently of Jules tasks. 

Key features:
- Independent sidebar block located below Repositories.
- Session navigation and active state highlighting with purple accent.
- Automatic session title generation (Title > First User Message > Default).
- Session deletion with 'Aceptar / Cancelar' confirmation.
- Integration with '+ Nueva sesión' for quick chat creation.
- Persistent storage using 'hy_jules_panel_neural_sessions'.
- Visual and functional isolation from the existing 'NEURAL HISTORY' block.

---
*PR created automatically by Jules for task [4582367386195221129](https://jules.google.com/task/4582367386195221129) started by @TopperH4rley*