### PR TITLE
Sync User Identity in Neural Chat

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Added</h5>
             <ul>
+                <li><strong>Identidad Visual en Neural Chat (Jules Panel):</strong> Ahora los mensajes del usuario en el Neural Chat muestran el avatar y el nombre real del usuario autenticado de GitHub (login o nombre real), manteniendo la coherencia con el header del panel y utilizando fallbacks seguros para modo invitado.</li>
                 <li><strong>Neural Chat History (Jules Panel):</strong> Implementada una nueva sección en la sidebar del Panel Jules llamada <code>NEURAL CHAT HISTORY</code>. Permite gestionar hilos de conversación con Claude de forma independiente a las tareas de Jules, con soporte para navegación entre sesiones, creación de nuevos chats y borrado con confirmación.</li>
                 <li><strong>Mejora de UX Móvil en Generadores:</strong> Rediseño de las interfaces de síntesis visual y sonora para dispositivos móviles. Implementado sistema de paneles laterales colapsables con backdrop, navegación optimizada para touch, scroll horizontal en selectores de modo y optimización de rendimiento en visualizadores de audio.</li>
                 <li><strong>Persistencia en Generadores (IndexedDB):</strong> Implementado sistema de almacenamiento robusto para imágenes y música generadas utilizando IndexedDB. Esto permite mantener un historial extenso de archivos binarios (Blobs) sin saturar el almacenamiento del navegador.</li>

--- a/assets/javascript/jules-activities.js
+++ b/assets/javascript/jules-activities.js
@@ -43,10 +43,24 @@ const JulesActivitiesModule = (() => {
 
   function _activityToHTML(act) {
     const time = new Date(act.createTime).toLocaleTimeString('es-ES');
-    const orig = (act.originator || 'system').toUpperCase();
-    let icon = '⚙️';
-    if (act.originator === 'agent') icon = '🤖';
-    if (act.originator === 'user') icon = '👤';
+    const originator = act.originator || 'system';
+
+    let iconHTML = '⚙️';
+    if (originator === 'agent') iconHTML = '🤖';
+    if (originator === 'user') iconHTML = '👤';
+
+    let displayName = originator.toUpperCase();
+
+    // Apply Authenticated User Identity if originator is user
+    if (originator === 'user') {
+      const githubUser = window.githubApi ? window.githubApi.user : null;
+      if (githubUser) {
+        displayName = (githubUser.login || githubUser.name || 'USUARIO').toUpperCase();
+        if (githubUser.avatar_url) {
+          iconHTML = `<img src="${githubUser.avatar_url}" style="width:24px; height:24px; border-radius:50%; object-fit:cover;">`;
+        }
+      }
+    }
 
     let content = act.description || '';
     let extraHTML = '';
@@ -93,11 +107,11 @@ const JulesActivitiesModule = (() => {
       </div>` : '';
 
     return `
-      <div class="jules-activity-entry jules-activity-entry--${act.originator || 'system'}" data-activity-id="${act.id}">
-        <span class="activity-icon">${icon}</span>
+      <div class="jules-activity-entry jules-activity-entry--${originator}" data-activity-id="${act.id}">
+        <span class="activity-icon">${iconHTML}</span>
         <div class="activity-body">
           <div class="activity-header">
-            <span class="activity-originator">${orig}</span>
+            <span class="activity-originator">${displayName}</span>
             <span class="activity-time">${time}</span>
           </div>
           <div class="activity-content">${content}</div>

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -284,15 +284,27 @@ window.renderChatV2Messages = function() {
     // Al renderizar historial, nos aseguramos que el indicador esté oculto
     setNeuralProcessingState(false);
 
+    const githubUser = window.githubApi ? window.githubApi.user : null;
+
     session.messages.forEach((msg, idx) => {
         const div = document.createElement('div');
         div.className = 'jules-activity-entry jules-activity-entry--' + (msg.role === 'assistant' ? 'agent' : 'user');
         div.dataset.id = 'local-' + idx;
 
-        const icon = msg.role === 'assistant' ? '🤖' : '👤';
-        const time = msg.timestamp ? new Date(msg.timestamp).toLocaleTimeString('es-ES') : '--:--';
         const isAssistant = msg.role === 'assistant';
         const isJules = msg.source === 'jules';
+        const time = msg.timestamp ? new Date(msg.timestamp).toLocaleTimeString('es-ES') : '--:--';
+
+        let iconHTML = isAssistant ? '🤖' : '👤';
+        let displayName = isJules ? 'JULES' : (isAssistant ? 'CLAUDE' : 'USUARIO');
+
+        // Apply Authenticated User Identity if role is user
+        if (!isAssistant && githubUser) {
+            displayName = githubUser.login || githubUser.name || 'USUARIO';
+            if (githubUser.avatar_url) {
+                iconHTML = '<img src="' + githubUser.avatar_url + '" style="width:24px; height:24px; border-radius:50%; object-fit:cover;">';
+            }
+        }
 
         const actionBtn = isAssistant ?
             '<div class="activity-actions" style="margin-top: 8px; display: flex; gap: 8px;">' +
@@ -304,10 +316,10 @@ window.renderChatV2Messages = function() {
         const renderedContent = isAssistant && window.marked ? marked.parse(msg.content) : window.NeuralChatCore.escapeHtml(msg.content);
 
         div.innerHTML =
-            '<span class="activity-icon">' + icon + '</span>' +
+            '<span class="activity-icon">' + iconHTML + '</span>' +
             '<div class="activity-body">' +
               '<div class="activity-header">' +
-                '<span class="activity-originator">' + (isJules ? 'JULES' : (isAssistant ? 'CLAUDE' : 'USUARIO')) + '</span>' +
+                '<span class="activity-originator">' + displayName + '</span>' +
                 '<span class="activity-time">' + time + '</span>' +
               '</div>' +
               '<div class="activity-content">' + renderedContent + '</div>' +


### PR DESCRIPTION
Updated the Neural Chat rendering logic to display the authenticated user's real GitHub login/name and avatar for their own messages. Added safe fallbacks for guest mode and maintained visual consistency with the panel header.

Summary of changes:
- Modified `assets/javascript/jules-panel-neural.js`: Updated `renderChatV2Messages` to resolve identity from `window.githubApi.user` at render-time.
- Modified `assets/javascript/jules-activities.js`: Updated `_activityToHTML` for consistency in real-time activity logs.
- Preserved existing data structures in localStorage.
- Ensured Claude/Jules messages and guest mode (fallback to 'USUARIO' and generic icon) remain unaffected.
- Updated `CHANGELOG.html`.

---
*PR created automatically by Jules for task [5617463257783352449](https://jules.google.com/task/5617463257783352449) started by @TopperH4rley*