### PR TITLE
Restore Enhanced Retro Dashboard Menu

### DIFF
--- a/_includes/nav_dashboard.html
+++ b/_includes/nav_dashboard.html
@@ -1,0 +1,67 @@
+<!-- Dashboard Top Navigation -->
+<header class="dashboard-nav-retro sticky top-0 z-50">
+    <div class="max-w-[1600px] mx-auto px-1.5 sm:px-4 md:px-6 h-16 flex items-center justify-between gap-1.5 sm:gap-4">
+
+        <!-- Left: Logo -->
+        <a href="/" class="flex-shrink-0 transition-transform hover:scale-105 active:scale-95 mr-1" data-title="Volver al Home">
+            <img src="https://raw.githubusercontent.com/hypenosys/hypenosys-logo/master/logo_simple.svg" alt="Hypenosys" class="h-6 sm:h-8 md:h-10 w-auto">
+        </a>
+
+        <!-- Middle/Right: Navigation & Tools -->
+        <div class="flex items-center gap-0.5 sm:gap-2 md:gap-4 ml-auto">
+            <!-- Internal Navigation Icons -->
+            <nav class="flex items-center gap-0.5 sm:gap-2 border-l border-slate-800 pl-1 sm:pl-4">
+                <a href="#kanban-board" class="nav-icon-btn" data-title="Kanban">
+                    <i class="fa-solid fa-table-columns"></i>
+                </a>
+                <a href="#pipeline" class="nav-icon-btn" data-title="Pipeline">
+                    <i class="fa-solid fa-industry"></i>
+                </a>
+                <a href="#group-stats-section" class="nav-icon-btn" data-title="Stats">
+                    <i class="fa-solid fa-chart-pie"></i>
+                </a>
+            </nav>
+
+            <!-- Tools Navigation (External) -->
+            <div class="flex items-center gap-0.5 sm:gap-2 border-l border-slate-800 pl-1 sm:pl-4">
+                <a href="/jules-panel/" class="nav-tool-btn text-emerald-400" data-title="Quick Jules">
+                    <i class="fa-solid fa-robot"></i>
+                </a>
+                <a href="/chat/neural/" class="nav-tool-btn text-purple-400" data-title="Neural Chat">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.886 3 3 0 1 0 5.174 2.688A4.497 4.497 0 0 1 12 18.5V5Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.52 5.886 3 3 0 1 1-5.174 2.688A4.497 4.497 0 0 0 12 18.5V5Z"/></svg>
+                </a>
+                <a href="/image-gen/" class="nav-tool-btn text-cyan-400" data-title="ImageGen">
+                    <i class="fa-solid fa-wand-magic-sparkles"></i>
+                </a>
+                <a href="/music-gen/" class="nav-tool-btn text-pink-400" data-title="MusicGen">
+                    <i class="fa-solid fa-music"></i>
+                </a>
+                <a href="/documentacion/" class="nav-tool-btn text-slate-400" data-title="Documentación">
+                    <i class="fa-solid fa-book"></i>
+                </a>
+                <a href="/tech-stack/" class="nav-tool-btn text-slate-400" data-title="Tech Stack">
+                    <i class="fa-solid fa-layer-group"></i>
+                </a>
+            </div>
+
+            <!-- User Section -->
+            <div id="user-status" class="flex items-center border-l border-slate-800 pl-1 sm:pl-4">
+                <!-- User avatar & name injected here by dashboard-ui.js -->
+            </div>
+            <!-- Hidden mobile container to avoid JS errors if a script expects it -->
+            <div id="user-status-mobile" class="hidden"></div>
+        </div>
+    </div>
+
+    <!-- Sub-header for Member Filters -->
+    <div class="bg-slate-950/50 border-t border-slate-800/50 py-2 px-4 md:px-6">
+        <div class="max-w-[1600px] mx-auto flex items-center justify-between gap-4">
+            <div id="member-filters" class="flex flex-wrap items-center gap-2">
+                <!-- Member filters injected here -->
+            </div>
+            <div id="last-sync-timestamp" class="hidden xl:block text-[10px] font-mono text-slate-500 uppercase tracking-widest">
+                Sincronizando...
+            </div>
+        </div>
+    </div>
+</header>

--- a/_includes/nav_dashboard_styles.html
+++ b/_includes/nav_dashboard_styles.html
@@ -1,0 +1,132 @@
+<style>
+    /* Dashboard Retro Navigation Styles */
+    .dashboard-nav-retro {
+        background: rgba(15, 23, 42, 0.9);
+        backdrop-filter: blur(12px);
+        border-bottom: 1px solid #1e293b;
+        box-shadow: 0 4px 20px -5px rgba(0, 0, 0, 0.5);
+    }
+
+    .nav-icon-btn, .nav-tool-btn {
+        width: 24px;
+        height: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+        background: rgba(15, 23, 42, 0.6);
+        border: 1px solid #334155;
+        color: #94a3b8;
+        transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+        cursor: pointer;
+        position: relative;
+        box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+    }
+
+    @media (min-width: 480px) {
+        .nav-icon-btn, .nav-tool-btn {
+            width: 32px;
+            height: 32px;
+            border-radius: 6px;
+        }
+    }
+
+    @media (min-width: 768px) {
+        .nav-icon-btn, .nav-tool-btn {
+            width: 38px;
+            height: 38px;
+            border-radius: 8px;
+        }
+    }
+
+    .nav-icon-btn:hover, .nav-tool-btn:hover {
+        background: rgba(51, 65, 85, 0.8);
+        border-color: #334155;
+        color: #fff;
+        transform: translateY(-2px);
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+    }
+
+    .nav-icon-btn:active, .nav-tool-btn:active {
+        transform: translateY(0);
+    }
+
+    .nav-tool-btn.text-emerald-400:hover { color: #34d399; border-color: rgba(52, 211, 153, 0.3); box-shadow: 0 0 10px rgba(52, 211, 153, 0.1); }
+    .nav-tool-btn.text-purple-400:hover { color: #c084fc; border-color: rgba(192, 132, 252, 0.3); box-shadow: 0 0 10px rgba(192, 132, 252, 0.1); }
+    .nav-tool-btn.text-cyan-400:hover { color: #22d3ee; border-color: rgba(34, 211, 238, 0.3); box-shadow: 0 0 10px rgba(34, 211, 238, 0.1); }
+    .nav-tool-btn.text-pink-400:hover { color: #f472b6; border-color: rgba(244, 114, 182, 0.3); box-shadow: 0 0 10px rgba(244, 114, 182, 0.1); }
+
+    /* Scanline Effect for Header */
+    .dashboard-nav-retro::before {
+        content: " ";
+        position: absolute;
+        top: 0; left: 0; bottom: 0; right: 0;
+        background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.05) 50%),
+                    linear-gradient(90deg, rgba(255, 0, 0, 0.01), rgba(0, 255, 0, 0.005), rgba(0, 0, 255, 0.01));
+        background-size: 100% 4px, 3px 100%;
+        pointer-events: none;
+        z-index: 10;
+        opacity: 0.5;
+    }
+
+    /* Glow bar under active navigation */
+    .nav-icon-btn::after {
+        content: "";
+        position: absolute;
+        bottom: -4px;
+        left: 50%;
+        width: 0;
+        height: 2px;
+        background: #10b981;
+        transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+        transform: translateX(-50%);
+        box-shadow: 0 0 8px #10b981, 0 0 15px rgba(16, 185, 129, 0.5);
+    }
+
+    .nav-icon-btn:hover::after {
+        width: 70%;
+    }
+
+    /* Custom Tooltip using data-title to avoid native tooltips */
+    .nav-icon-btn:hover::before, .nav-tool-btn:hover::before, a[data-title]:hover::before {
+        content: attr(data-title);
+        position: absolute;
+        bottom: -35px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: #1e293b;
+        color: #f8fafc;
+        padding: 4px 10px;
+        border-radius: 4px;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        white-space: nowrap;
+        z-index: 100;
+        border: 1px solid #334155;
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
+        pointer-events: none;
+        opacity: 0;
+        animation: tooltip-fade-in 0.2s forwards 0.1s;
+    }
+
+    @keyframes tooltip-fade-in {
+        from { opacity: 0; transform: translate(-50%, 5px); }
+        to { opacity: 1; transform: translate(-50%, 0); }
+    }
+
+    /* User Profile Retro Style */
+    #user-status button {
+        background: rgba(30, 41, 59, 0.5);
+        border: 1px solid #1e293b;
+        padding: 4px 12px 4px 4px;
+        border-radius: 12px;
+        transition: all 0.2s ease;
+    }
+
+    #user-status button:hover {
+        background: rgba(51, 65, 85, 0.5);
+        border-color: #334155;
+    }
+</style>

--- a/dashboard.html
+++ b/dashboard.html
@@ -16,6 +16,7 @@ layout: null
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    {% include nav_dashboard_styles.html %}
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
         body { font-family: 'Inter', system-ui, sans-serif; }
@@ -115,72 +116,7 @@ layout: null
 </head>
 <body class="h-full text-slate-100 flex flex-col">
 
-    <!-- Top Navigation / Filter Bar -->
-    <header class="bg-slate-900 border-b border-slate-800 px-4 md:px-6 py-3 lg:py-4 sticky top-0 z-40">
-        <div class="max-w-[1600px] mx-auto w-full flex flex-col gap-4">
-
-            <!-- Row 1: Logo & Actions -->
-            <div class="flex items-center justify-between w-full gap-4">
-                <div class="flex items-center gap-2 sm:gap-4 overflow-hidden">
-                    <a href="/" class="text-emerald-400 text-lg md:text-2xl font-bold tracking-tighter flex items-center gap-2 flex-shrink-0">
-                        <i class="fa-solid fa-microchip"></i> <span class="flex-shrink-0">HYPENOSYS</span> <span class="text-slate-500 font-light text-sm tracking-normal hidden sm:inline">OPS</span>
-                    </a>
-
-                    <!-- Nav Links - Hidden on very small screens, visible on tablet/desktop -->
-                    <nav class="hidden md:flex items-center ml-2 lg:ml-4 gap-3 lg:gap-4 mr-2 border-r border-slate-800 pr-4 lg:pr-6">
-                        <a href="#kanban-board" class="text-[10px] lg:text-xs font-bold text-slate-400 hover:text-white transition-all uppercase whitespace-nowrap">Kanban</a>
-                        <a href="#pipeline" class="text-[10px] lg:text-xs font-bold text-slate-400 hover:text-white transition-all uppercase whitespace-nowrap">Pipeline</a>
-                    </nav>
-                </div>
-
-                <!-- Desktop Right Side -->
-                <div class="hidden lg:flex items-center gap-4 ml-auto flex-shrink-0">
-                    <button onclick="window.location.href='/jules-panel/'" class="bg-slate-800 hover:bg-slate-700 text-emerald-400 px-3 py-2 rounded-lg transition-all border border-slate-700 flex items-center gap-2 text-xs font-bold" title="Quick Jules">
-                        <i class="fa-solid fa-robot"></i> <span>Quick Jules</span>
-                    </button>
-                    <button onclick="window.location.href='/chat/neural/'" class="bg-slate-800 hover:bg-slate-700 text-purple-400 px-3 py-2 rounded-lg transition-all border border-slate-700 flex items-center gap-2 text-xs font-bold" title="Neural Chat">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.886 3 3 0 1 0 5.174 2.688A4.497 4.497 0 0 1 12 18.5V5Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.52 5.886 3 3 0 1 1-5.174 2.688A4.497 4.497 0 0 0 12 18.5V5Z"/></svg> <span>Neural Chat</span>
-                    </button>
-                    <button onclick="window.location.href='/image-gen/'" class="bg-slate-800 hover:bg-slate-700 text-cyan-400 px-3 py-2 rounded-lg transition-all border border-slate-700 flex items-center gap-2 text-xs font-bold" title="ImageGen">
-                        <i class="fa-solid fa-wand-magic-sparkles"></i> <span>ImageGen</span>
-                    </button>
-                    <button onclick="window.location.href='/music-gen/'" class="bg-slate-800 hover:bg-slate-700 text-pink-400 px-3 py-2 rounded-lg transition-all border border-slate-700 flex items-center gap-2 text-xs font-bold" title="MusicGen">
-                        <i class="fa-solid fa-music"></i> <span>MusicGen</span>
-                    </button>
-                    <div id="last-sync-timestamp" class="hidden xl:block text-[10px] font-mono text-slate-500 uppercase tracking-widest">
-                        Sincronizando...
-                    </div>
-                    <div id="user-status" class="flex items-center gap-3">
-                        <!-- User avatar desktop -->
-                    </div>
-                </div>
-
-                <!-- Mobile Quick Actions -->
-                <div class="flex lg:hidden items-center gap-2 sm:gap-3 flex-shrink-0">
-                    <button onclick="window.location.href='/jules-panel/'" class="bg-slate-800 hover:bg-slate-700 text-emerald-400 p-2 rounded-lg transition-all border border-slate-700 flex items-center justify-center" title="Quick Jules">
-                        <i class="fa-solid fa-robot"></i>
-                    </button>
-                    <button onclick="window.location.href='/chat/neural/'" class="bg-slate-800 hover:bg-slate-700 text-purple-400 p-2 rounded-lg transition-all border border-slate-700 flex items-center justify-center" title="Neural Chat">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.886 3 3 0 1 0 5.174 2.688A4.497 4.497 0 0 1 12 18.5V5Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.52 5.886 3 3 0 1 1-5.174 2.688A4.497 4.497 0 0 0 12 18.5V5Z"/></svg>
-                    </button>
-                    <button onclick="window.location.href='/image-gen/'" class="bg-slate-800 hover:bg-slate-700 text-cyan-400 p-2 rounded-lg transition-all border border-slate-700 flex items-center justify-center" title="ImageGen">
-                        <i class="fa-solid fa-wand-magic-sparkles"></i>
-                    </button>
-                    <button onclick="window.location.href='/music-gen/'" class="bg-slate-800 hover:bg-slate-700 text-pink-400 p-2 rounded-lg transition-all border border-slate-700 flex items-center justify-center" title="MusicGen">
-                        <i class="fa-solid fa-music"></i>
-                    </button>
-                    <div id="user-status-mobile" class="flex items-center">
-                        <!-- User avatar mobile -->
-                    </div>
-                </div>
-            </div>
-
-            <!-- Row 2: Member Filters -->
-            <div id="member-filters" class="flex flex-wrap items-center gap-2 bg-slate-950/50 p-1 rounded-lg border border-slate-800/50">
-                <!-- Member filters injected here -->
-            </div>
-        </div>
-    </header>
+    {% include nav_dashboard.html %}
 
     <main class="flex-grow p-6 space-y-8 max-w-[1600px] mx-auto w-full">
         


### PR DESCRIPTION
This PR restores the missing top navigation menu in the dashboard and significantly enhances its visual style and architecture.

Key changes:
1. **Abstraction**: Moved the dashboard header and its specific retro styles to Jekyll includes (`_includes/nav_dashboard.html` and `_includes/nav_dashboard_styles.html`) for better maintainability and future standardization across other pages.
2. **Retro Visuals**: Applied a modern-retro "app" aesthetic featuring:
   - Backdrop blur and subtle transparency.
   - CRT-style scanline overlay.
   - Hover-glow effects on icons.
   - Custom-styled tooltips using `data-title`.
3. **Menu Content**:
   - **Logo**: Updated to the requested `logo_simple.svg`.
   - **Internal Nav**: Added icons for Kanban, Pipeline, and Stats.
   - **Tools**: Reordered and restored links to Quick Jules, Neural Chat, ImageGen, MusicGen, Documentation, and Tech Stack.
4. **Mobile Optimization**:
   - Implemented a "No-Hide" mobile strategy, using responsive sizing (24px to 38px) to keep all icons accessible even on small mobile screens without overflow.
5. **Robustness**:
   - Converted tool buttons to `<a>` tags for standard browser behavior.
   - Maintained both `user-status` and `user-status-mobile` IDs to ensure full compatibility with the existing `auth.js` and `dashboard-ui.js` scripts.

Verified via Playwright screenshots on both desktop and mobile viewports.

---
*PR created automatically by Jules for task [15598341652476145127](https://jules.google.com/task/15598341652476145127) started by @Axlfc*