### PR TITLE
Link Neural History Sidebar to Kanban Cards

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -77,6 +77,7 @@ permalink: /CHANGELOG.html
                 <li><strong>Restauración Completa de Contexto:</strong> Al seleccionar un elemento del historial, el sistema ahora restaura todos los parámetros originales (Seed, Steps, Resolution, BPM, Key, Lyrics, etc.) permitiendo iterar sobre generaciones previas con precisión.</li>
                 <li><strong>Autenticación en Generadores:</strong> Implementado sistema de control de acceso para <code>/image-gen/</code> y <code>/music-gen/</code>. Las páginas ahora cuentan con overlays de carga, login y acceso denegado, restringiendo el uso exclusivamente a miembros autorizados del equipo Hypenosys.</li>
                 <li><strong>Acciones de Sesión en Neural History (Jules Panel):</strong> Implementadas funciones para renombrar, archivar y borrar sesiones directamente desde el historial. Incluye confirmación de borrado, filtrado de archivados y selección automática de sesión activa tras cambios.</li>
+                <li><strong>Vinculación Sidebar-Kanban (Jules Panel):</strong> Al hacer clic en una sesión del historial neural en el menú lateral, el panel ahora navega automáticamente a la vista Kanban, resalta visualmente la tarjeta correspondiente con una animación de brillo y asegura que sea visible mediante scroll automático.</li>
             </ul>
             <h5 class="text-success">Changed</h5>
             <ul>

--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -929,6 +929,16 @@ body{
 }
 .notif-pip.hidden{display:none}
 @keyframes notif-pop{from{transform:scale(0)}to{transform:scale(1)}}
+@keyframes highlight-glow {
+  0% { box-shadow: 0 0 0px rgba(124, 58, 237, 0); border-color: var(--border); }
+  50% { box-shadow: 0 0 25px rgba(124, 58, 237, 0.6); border-color: var(--accent); }
+  100% { box-shadow: 0 0 0px rgba(124, 58, 237, 0); border-color: var(--border); }
+}
+.kb-card.highlight-focus {
+  animation: highlight-glow 2s ease-in-out 3;
+  border-color: var(--accent) !important;
+  z-index: 10;
+}
 .notif-panel{
   position:fixed;top:70px;right:16px;width:340px;z-index:200;
   border-radius:var(--r-xl);overflow:hidden;

--- a/assets/javascript/jules-panel-sessions.js
+++ b/assets/javascript/jules-panel-sessions.js
@@ -178,6 +178,30 @@ window.selectSession = function(sessionName) {
         tr.classList.toggle('active-row', trSid === sid);
     });
 
+    // Navigate to Kanban and Highlight
+    if (typeof switchView === 'function') {
+        switchView('kanban');
+
+        // Wait for view switch and cards to be potentially rendered/available
+        setTimeout(() => {
+            const card = document.querySelector('.kb-card[data-sid="' + sid + '"]');
+            if (card) {
+                // Clear previous highlights
+                document.querySelectorAll('.kb-card.highlight-focus').forEach(c => c.classList.remove('highlight-focus'));
+
+                // Add focus highlight
+                card.classList.add('highlight-focus');
+
+                // Ensure it's visible
+                card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+                console.log("[JULES-UI] Session #" + sid + " highlighted in Kanban.");
+            } else {
+                console.warn("[JULES-UI] Could not find card for #" + sid + " in Kanban view.");
+            }
+        }, 300);
+    }
+
     openDrawer(sessionName);
 }
 


### PR DESCRIPTION
Implement visual linking between the Neural History sidebar and the Kanban board. When a session is selected from the sidebar, the application now navigates to the Kanban view, applies a highlight animation to the matching card, and scrolls it into view for immediate focus.

---
*PR created automatically by Jules for task [16130810840520123283](https://jules.google.com/task/16130810840520123283) started by @Axlfc*