### PR TITLE
Unify Neural Sessions and implement Session-Task linking

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -67,6 +67,14 @@ permalink: /CHANGELOG.html
             <ul>
                 <li><strong>Jules Panel Header:</strong> Eliminado el bloque defectuoso (breadcrumb blanco) en el header superior para una estética oscura limpia.</li>
             </ul>
+            <h5 class="text-purple">Added</h5>
+            <ul>
+                <li><strong>Unificación de Sesiones Neurales:</strong> Implementada la sincronización bidireccional de conversaciones entre el Jules Panel y Neural Chat (Standalone) usando <code>claude_chat_sessions</code> como fuente de verdad única.</li>
+                <li><strong>Vinculación Persistente Jules-Claude:</strong> Introducido el sistema de enlace entre hilos de Claude y tareas técnicas de Jules mediante metadatos (<code>linkedJulesTaskId</code>), permitiendo un flujo de trabajo fluido entre análisis y ejecución.</li>
+                <li><strong>Selector de Contexto Inteligente:</strong> El envío de mensajes hacia Jules ahora detecta automáticamente la falta de conversación activa o tarea vinculada, abriendo selectores integrados sin perder el mensaje del usuario.</li>
+                <li><strong>UI de Estado de Vínculo:</strong> Nueva barra de estado en el chat de Jules Panel que muestra la vinculación actual y ofrece acciones rápidas para cambiar de tarea o desvincular el contexto técnico.</li>
+                <li><strong>Migración Defensiva de Datos:</strong> Implementado motor de migración que fusiona sesiones antiguas del panel con el almacenamiento unificado de Claude sin pérdida de mensajes ni duplicados.</li>
+            </ul>
             <h5 class="text-success">Added</h5>
             <ul>
                 <li><strong>Contexto Dinámico en Sidebar (Jules Panel):</strong> Implementado un label dinámico en el sidebar que muestra el repositorio activo (o su alias) basándose en la sesión neural cargada o la selección manual.</li>

--- a/_includes/jules-panel-styles.html
+++ b/_includes/jules-panel-styles.html
@@ -525,6 +525,31 @@ body{
 .chat-history-item:hover .btn-delete-session {
   opacity: 1;
 }
+
+.chat-history-item.linked {
+    border-left: 3px solid var(--accent2);
+    padding-left: 9px;
+}
+
+.chat-content-wrap {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.chat-link-meta {
+    font-size: 8px;
+    font-weight: 800;
+    color: var(--accent2);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 2px;
+    opacity: 0.8;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .chat-history-item .btn-delete-session:hover {
   color: var(--red);
   background: var(--red-soft);

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -2,8 +2,8 @@
    JULES PANEL NEURAL & CHAT MODULE
    ════════════════════════════════════════ */
 
-window.JULES_PANEL_NEURAL_STORAGE = 'hy_jules_panel_neural_sessions';
-window.JULES_PANEL_NEURAL_ACTIVE_ID = 'hy_jules_panel_neural_active_id';
+window.JULES_PANEL_NEURAL_STORAGE = 'claude_chat_sessions';
+window.JULES_PANEL_NEURAL_ACTIVE_ID = 'hy_active_claude_session_id';
 
 window.julesPanelSessions = [];
 window.currentJulesPanelSessionId = null;
@@ -46,6 +46,75 @@ window.loadJulesPanelSessions = function() {
 }
 
 /**
+ * Migración defensiva de sesiones del panel a la key unificada de Claude.
+ */
+function migrateJulesPanelSessions() {
+    const OLD_KEY = 'hy_jules_panel_neural_sessions';
+    const NEW_KEY = 'claude_chat_sessions';
+    const OLD_ACTIVE_ID = 'hy_jules_panel_neural_active_id';
+    const NEW_ACTIVE_ID = 'hy_active_claude_session_id';
+
+    const oldData = localStorage.getItem(OLD_KEY);
+    if (!oldData || localStorage.getItem(OLD_KEY + '_migrated') === 'true') return;
+
+    try {
+        const oldSessions = JSON.parse(oldData);
+        if (!Array.isArray(oldSessions) || oldSessions.length === 0) return;
+
+        console.log("[Migration] Migrating Jules Panel sessions to unified Claude storage...");
+
+        // Backup
+        localStorage.setItem('hy_bak_' + OLD_KEY, oldData);
+        const currentClaudeData = localStorage.getItem(NEW_KEY);
+        if (currentClaudeData) localStorage.setItem('hy_bak_' + NEW_KEY, currentClaudeData);
+
+        let claudeSessions = JSON.parse(currentClaudeData || '[]');
+        let migratedCount = 0;
+
+        oldSessions.forEach(oldSess => {
+            const existingIdx = claudeSessions.findIndex(s => s.id === oldSess.id);
+            if (existingIdx !== -1) {
+                // Fusionar mensajes
+                const existing = claudeSessions[existingIdx];
+                oldSess.messages.forEach(m => {
+                    const exists = existing.messages.some(em =>
+                        em.content === m.content && em.role === m.role && em.timestamp === m.timestamp
+                    );
+                    if (!exists) {
+                        existing.messages.push(m);
+                        existing.messages.sort((a,b) => (a.timestamp || 0) - (b.timestamp || 0));
+                    }
+                });
+                // Preservar metadata del panel
+                existing.metadata = existing.metadata || {};
+                if (oldSess.repoFullName) existing.metadata.repoFullName = oldSess.repoFullName;
+                if (oldSess.repoName) existing.metadata.repoName = oldSess.repoName;
+            } else {
+                // Nueva sesión, normalizar metadata
+                oldSess.metadata = oldSess.metadata || {};
+                if (oldSess.repoFullName) oldSess.metadata.repoFullName = oldSess.repoFullName;
+                if (oldSess.repoName) oldSess.metadata.repoName = oldSess.repoName;
+                claudeSessions.push(oldSess);
+                migratedCount++;
+            }
+        });
+
+        localStorage.setItem(NEW_KEY, JSON.stringify(claudeSessions));
+        localStorage.setItem(OLD_KEY + '_migrated', 'true');
+
+        // Sync active ID if needed
+        const oldActiveId = localStorage.getItem(OLD_ACTIVE_ID);
+        if (oldActiveId && !localStorage.getItem(NEW_ACTIVE_ID)) {
+            localStorage.setItem(NEW_ACTIVE_ID, oldActiveId);
+        }
+
+        console.log(`[Migration] Successfully migrated ${migratedCount} sessions.`);
+    } catch (e) {
+        console.error("[Migration] Error migrating sessions:", e);
+    }
+}
+
+/**
  * Initialize Neural Chat for Jules Panel
  */
 window.initJulesPanelNeuralChat = function() {
@@ -56,12 +125,13 @@ window.initJulesPanelNeuralChat = function() {
     }
     console.log("[Jules Panel Neural] Initializing...");
 
+    migrateJulesPanelSessions();
     setNeuralProcessingState(false);
     window.loadJulesPanelSessions();
 
-    if (window.julesPanelSessions.length === 0) {
+    if (window.julesPanelSessions.length === 0 && !window.location.search.includes('skip_auto_session')) {
         window.createNewJulesPanelSession();
-    } else if (!window.currentJulesPanelSessionId) {
+    } else if (!window.currentJulesPanelSessionId && !window.location.search.includes('skip_auto_session')) {
         window.loadJulesPanelSession(window.julesPanelSessions[0].id);
     } else {
         window.loadJulesPanelSession(window.currentJulesPanelSessionId);
@@ -149,14 +219,15 @@ function _syncJulesActivitiesToSession(activities) {
 window.createNewJulesPanelSession = function() {
     const newSession = window.NeuralChatCore.createSession({
         title: 'Nueva Conversación',
-        idPrefix: 'jp_sess_'
+        idPrefix: 'session_'
     });
 
     // Auto-associate with current repo
     const currentRepo = localStorage.getItem('hypenosys_active_repo');
+    newSession.metadata = newSession.metadata || {};
     if (currentRepo) {
-        newSession.repoFullName = currentRepo;
-        newSession.repoName = currentRepo.split('/').pop();
+        newSession.metadata.repoFullName = currentRepo;
+        newSession.metadata.repoName = currentRepo.split('/').pop();
     }
 
     window.julesPanelSessions.unshift(newSession);
@@ -203,17 +274,20 @@ window.sendChatV2Msg = async function() {
     // AI/Claude mode
     const session = window.julesPanelSessions.find(s => s.id === window.currentJulesPanelSessionId);
     if (!session) {
+        // En lugar de crear una nueva, pedimos seleccionar una o crearla.
+        // Pero para mantener compatibilidad simple por ahora, la creamos si no hay ninguna.
         window.createNewJulesPanelSession();
         setTimeout(() => window.sendChatV2Msg(), 100);
         return;
     }
 
     // Ensure repo association on first message if missing
-    if (!session.repoFullName) {
+    if (!session.metadata?.repoFullName) {
         const currentRepo = localStorage.getItem('hypenosys_active_repo');
         if (currentRepo) {
-            session.repoFullName = currentRepo;
-            session.repoName = currentRepo.split('/').pop();
+            session.metadata = session.metadata || {};
+            session.metadata.repoFullName = currentRepo;
+            session.metadata.repoName = currentRepo.split('/').pop();
             if (window.updateSidebarContextLabel) window.updateSidebarContextLabel();
         }
     }
@@ -277,9 +351,15 @@ window.renderNeuralChatHistory = function() {
             }
         }
 
-        return '<div class="chat-history-item' + (isActive ? ' active' : '') + '" onclick="window.loadJulesPanelSession(\'' + s.id + '\')">' +
+        const isLinked = s.metadata && s.metadata.linkedJulesTaskId;
+        const linkedTitle = isLinked ? (s.metadata.linkedJulesTaskTitle || s.metadata.linkedJulesTaskId) : '';
+
+        return '<div class="chat-history-item' + (isActive ? ' active' : '') + (isLinked ? ' linked' : '') + '" onclick="window.loadJulesPanelSession(\'' + s.id + '\')">' +
                  '<div class="chat-dot"></div>' +
-                 '<div class="chat-title" title="' + window.NeuralChatCore.escapeHtml(displayTitle) + '">' + window.NeuralChatCore.escapeHtml(displayTitle) + '</div>' +
+                 '<div class="chat-content-wrap">' +
+                    '<div class="chat-title" title="' + window.NeuralChatCore.escapeHtml(displayTitle) + '">' + window.NeuralChatCore.escapeHtml(displayTitle) + '</div>' +
+                    (isLinked ? '<div class="chat-link-meta"><i class="fas fa-link"></i> ' + window.NeuralChatCore.escapeHtml(linkedTitle) + '</div>' : '') +
+                 '</div>' +
                  '<button class="btn-delete-session" onclick="window.deleteJulesPanelSession(event, \'' + s.id + '\')" title="Borrar">' +
                    '<i class="fas fa-trash"></i>' +
                  '</button>' +
@@ -292,6 +372,31 @@ window.renderChatV2Messages = function() {
     if (!container) return;
 
     const session = window.julesPanelSessions.find(s => s.id === window.currentJulesPanelSessionId);
+
+    // Update Linking Status Bar
+    const statusLabel = $('chat-live-status');
+    const statusMonitor = $('chat-live-monitor');
+
+    if (!session) {
+        if (statusLabel) statusLabel.innerHTML = 'No hay conversación activa vinculada. <button onclick="window.openClaudeSessionSelector()" class="btn btn-ghost btn-xs" style="color:var(--accent2); text-decoration:underline; margin-left:10px">Elegir conversación</button>';
+        if (statusMonitor) statusMonitor.classList.remove('hidden');
+    } else {
+        const isLinked = session.metadata && session.metadata.linkedJulesTaskId;
+        const linkedTitle = isLinked ? (session.metadata.linkedJulesTaskTitle || session.metadata.linkedJulesTaskId) : 'Ninguna';
+
+        if (statusLabel) {
+            if (isLinked) {
+                statusLabel.innerHTML = `Conversación: <strong>${window.NeuralChatCore.escapeHtml(session.title)}</strong> · Jules: <strong>${window.NeuralChatCore.escapeHtml(linkedTitle)}</strong>
+                <button onclick="window.openJulesTaskSelector()" class="btn btn-ghost btn-xs" style="color:var(--accent2); margin-left:10px">Cambiar tarea</button>
+                <button onclick="window.unlinkClaudeFromJulesTask('${session.id}')" class="btn btn-ghost btn-xs" style="color:var(--red); margin-left:5px">Desvincular</button>`;
+            } else {
+                statusLabel.innerHTML = `Conversación: <strong>${window.NeuralChatCore.escapeHtml(session.title)}</strong> · Sin tarea Jules vinculada
+                <button onclick="window.openJulesTaskSelector()" class="btn btn-ghost btn-xs" style="color:var(--accent2); margin-left:10px">Vincular tarea Jules</button>`;
+            }
+        }
+        if (statusMonitor) statusMonitor.classList.remove('hidden');
+    }
+
     if (!session) return;
 
     const welcome = container.querySelector('#v2-welcome-screen');
@@ -512,7 +617,11 @@ window.sendNeuralMessage = async function() {
     if (!msg) return;
 
     const sid = getLinkedJulesSessionId();
-    if (!sid) { showToast("No hay sesión activa vinculada", "red"); return; }
+    if (!sid) {
+        // Intercept and open linkers
+        window.handleJulesSendInterception(msg);
+        return;
+    }
 
     const targetId = sid.startsWith('sessions/') ? sid : 'sessions/' + sid;
     input.value = '';
@@ -548,6 +657,130 @@ window.approvePlan = async function(sessionId) {
 }
 
 // Ensure error handling doesn't use template literals
+/**
+ * Intercepta el envío a Jules cuando falta contexto (Conversación o Tarea)
+ */
+window.handleJulesSendInterception = function(message) {
+    window.pendingJulesMessage = message;
+
+    // 1. Validar conversación Claude
+    if (!window.currentJulesPanelSessionId) {
+        window.openClaudeSessionSelector();
+        return;
+    }
+
+    // 2. Validar vínculo a tarea Jules
+    const sid = getLinkedJulesSessionId();
+    if (!sid) {
+        window.openJulesTaskSelector();
+        return;
+    }
+
+    // Si llegamos aquí por error, reintentar envío normal
+    window.sendNeuralMessage();
+}
+
+/**
+ * Abre un selector para elegir una conversación de Claude existente
+ */
+window.openClaudeSessionSelector = function() {
+    const sessions = window.NeuralChatCore.getSessions(window.JULES_PANEL_NEURAL_STORAGE);
+
+    let html = '<div style="margin-bottom:15px; font-size:13px; color:var(--text2)">Selecciona una conversación de Claude para activar en el panel:</div>';
+
+    if (sessions.length === 0) {
+        html += '<div style="padding:20px; text-align:center; border:1px dashed var(--border); border-radius:8px; font-size:12px;">No hay conversaciones disponibles.</div>';
+    } else {
+        html += '<div style="max-height:300px; overflow-y:auto; display:flex; flex-direction:column; gap:8px;">';
+        sessions.slice(0, 15).forEach(s => {
+            html += `<button onclick="window.selectClaudeFromSelector('${s.id}')" class="btn btn-ghost" style="width:100%; justify-content:flex-start; text-align:left; padding:10px; height:auto;">
+                <div style="font-weight:700; font-size:12px; margin-bottom:2px;">${window.NeuralChatCore.escapeHtml(s.title)}</div>
+                <div style="font-size:10px; color:var(--text3); font-family:var(--font-mono); opacity:0.7;">ID: ${s.id.slice(-8)} · ${new Date(s.createdAt).toLocaleDateString()}</div>
+            </button>`;
+        });
+        html += '</div>';
+    }
+
+    // Usar modal genérico si existe o crear uno rápido
+    const modalHtml = `
+        <div id="neural-selector-modal" class="modal-overlay open" style="z-index:9999">
+            <div class="modal-card glass" style="max-width:400px">
+                <div class="modal-head">
+                    <h3 class="modal-title">Conversación Claude</h3>
+                    <button class="icon-btn" onclick="document.getElementById('neural-selector-modal').remove()">✕</button>
+                </div>
+                <div class="modal-body">${html}</div>
+                <div class="modal-foot">
+                    <button class="btn btn-primary btn-sm" onclick="window.createNewJulesPanelSession(); document.getElementById('neural-selector-modal').remove(); setTimeout(()=>window.handleJulesSendInterception(window.pendingJulesMessage), 300);">+ Nueva Conversación</button>
+                    <button class="btn btn-ghost btn-sm" onclick="document.getElementById('neural-selector-modal').remove()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+    `;
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+}
+
+window.selectClaudeFromSelector = function(id) {
+    document.getElementById('neural-selector-modal').remove();
+    window.loadJulesPanelSession(id);
+    // Re-evaluar siguiente paso
+    setTimeout(() => window.handleJulesSendInterception(window.pendingJulesMessage), 100);
+}
+
+/**
+ * Abre un selector para elegir una tarea de Jules (Jules Session) real
+ */
+window.openJulesTaskSelector = function() {
+    const tasks = window.julesSessionsCache || [];
+
+    let html = '<div style="margin-bottom:15px; font-size:13px; color:var(--text2)">Selecciona la tarea de Jules a la que quieres enviar este mensaje:</div>';
+
+    if (tasks.length === 0) {
+        html += '<div style="padding:20px; text-align:center; border:1px dashed var(--border); border-radius:8px; font-size:12px;">No se encontraron tareas de Jules recientes.</div>';
+    } else {
+        html += '<div style="max-height:300px; overflow-y:auto; display:flex; flex-direction:column; gap:8px;">';
+        tasks.slice(0, 15).forEach(t => {
+            const sid = t.name.split('/').pop();
+            const title = t.title || t.prompt || 'Sin título';
+            html += `<button onclick="window.selectJulesTaskFromSelector('${sid}', '${window.NeuralChatCore.escapeHtml(title).replace(/'/g, "\\'")}')" class="btn btn-ghost" style="width:100%; justify-content:flex-start; text-align:left; padding:10px; height:auto;">
+                <div style="font-weight:700; font-size:12px; margin-bottom:2px;">${window.NeuralChatCore.escapeHtml(title)}</div>
+                <div style="font-size:10px; color:var(--text3); font-family:var(--font-mono); opacity:0.7;">#${sid} · ${t.state}</div>
+            </button>`;
+        });
+        html += '</div>';
+    }
+
+    const modalHtml = `
+        <div id="neural-selector-modal" class="modal-overlay open" style="z-index:9999">
+            <div class="modal-card glass" style="max-width:400px">
+                <div class="modal-head">
+                    <h3 class="modal-title">Vincular Tarea Jules</h3>
+                    <button class="icon-btn" onclick="document.getElementById('neural-selector-modal').remove()">✕</button>
+                </div>
+                <div class="modal-body">${html}</div>
+                <div class="modal-foot">
+                    <button class="btn btn-primary btn-sm" onclick="document.getElementById('neural-selector-modal').remove(); switchView('neural'); showToast('Crea la tarea antes de vincularla', 'info');">+ Nueva Tarea Jules</button>
+                    <button class="btn btn-ghost btn-sm" onclick="document.getElementById('neural-selector-modal').remove()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+    `;
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+}
+
+window.selectJulesTaskFromSelector = function(sid, title) {
+    document.getElementById('neural-selector-modal').remove();
+    window.linkClaudeToJulesTask(window.currentJulesPanelSessionId, sid, title);
+
+    // Todo listo, enviar mensaje final
+    if (window.pendingJulesMessage) {
+        const input = $('v2-chat-input');
+        if (input) input.value = window.pendingJulesMessage;
+        window.sendNeuralMessage();
+        window.pendingJulesMessage = null;
+    }
+}
+
 window.handleJulesApiError = function(e) {
     const msg = e.message || ("HTTP " + e.httpStatus);
     showToast("Error de API: " + msg, "red");
@@ -572,6 +805,63 @@ window.renameJulesPanelSession = function(event, id) {
             window.renderChatV2Messages();
         }
         showToast("Sesión renombrada", "green");
+    }
+}
+
+/**
+ * Vincula una conversación de Claude con una tarea de Jules
+ */
+window.linkClaudeToJulesTask = function(claudeId, julesTaskId, julesTaskTitle) {
+    if (!claudeId || !julesTaskId) return;
+
+    const sessions = window.NeuralChatCore.getSessions(window.JULES_PANEL_NEURAL_STORAGE);
+    const session = sessions.find(s => s.id === claudeId);
+
+    if (session) {
+        session.metadata = session.metadata || {};
+        session.metadata.linkedJulesTaskId = julesTaskId;
+        session.metadata.linkedJulesTaskTitle = julesTaskTitle || julesTaskId;
+        session.metadata.updatedAt = new Date().toISOString();
+
+        window.NeuralChatCore.saveSessions(window.JULES_PANEL_NEURAL_STORAGE, sessions);
+        window.loadJulesPanelSessions(); // Refresh local cache
+
+        // Legacy sync
+        localStorage.setItem('hy_neural_session_id_' + claudeId, julesTaskId);
+        if (claudeId === window.currentJulesPanelSessionId) {
+            localStorage.setItem('hy_neural_session_id', julesTaskId);
+            window.renderChatV2Messages();
+        }
+
+        showToast("Conversación vinculada a la tarea de Jules", "green");
+    }
+}
+
+/**
+ * Desvincula una conversación de Claude de su tarea de Jules
+ */
+window.unlinkClaudeFromJulesTask = function(claudeId) {
+    if (!claudeId) return;
+
+    const sessions = window.NeuralChatCore.getSessions(window.JULES_PANEL_NEURAL_STORAGE);
+    const session = sessions.find(s => s.id === claudeId);
+
+    if (session && session.metadata) {
+        delete session.metadata.linkedJulesTaskId;
+        delete session.metadata.linkedJulesTaskTitle;
+        session.metadata.updatedAt = new Date().toISOString();
+
+        window.NeuralChatCore.saveSessions(window.JULES_PANEL_NEURAL_STORAGE, sessions);
+        window.loadJulesPanelSessions();
+
+        // Legacy cleanup
+        localStorage.removeItem('hy_neural_session_id_' + claudeId);
+        if (claudeId === window.currentJulesPanelSessionId) {
+            localStorage.removeItem('hy_neural_session_id');
+            window.renderChatV2Messages();
+        }
+
+        showToast("Vínculo con Jules eliminado", "amber");
     }
 }
 

--- a/assets/javascript/jules-panel-sessions.js
+++ b/assets/javascript/jules-panel-sessions.js
@@ -402,6 +402,13 @@ window.refreshActivities = async function(sessionId) {
 window.getLinkedJulesSessionId = function() {
     const claudeId = localStorage.getItem('hy_active_claude_session_id');
     if (claudeId) {
+        // First check in session metadata (new unified way)
+        const sessions = JSON.parse(localStorage.getItem('claude_chat_sessions') || '[]');
+        const current = sessions.find(s => s.id === claudeId);
+        if (current && current.metadata && current.metadata.linkedJulesTaskId) {
+            return current.metadata.linkedJulesTaskId;
+        }
+        // Fallback to legacy mapping
         return localStorage.getItem('hy_neural_session_id_' + claudeId) || localStorage.getItem('hy_neural_session_id');
     }
     return localStorage.getItem('hy_neural_session_id');

--- a/assets/javascript/jules-panel-ui.js
+++ b/assets/javascript/jules-panel-ui.js
@@ -402,12 +402,12 @@ window.updateSidebarContextLabel = function() {
     let repoName = null;
 
     // 1. Intentar obtener repo de la sesión neural activa
-    const activeSessionId = localStorage.getItem(window.JULES_PANEL_NEURAL_ACTIVE_ID || 'hy_jules_panel_neural_active_id');
+    const activeSessionId = localStorage.getItem('hy_active_claude_session_id');
     if (activeSessionId && window.julesPanelSessions) {
         const session = window.julesPanelSessions.find(s => s.id === activeSessionId);
-        if (session && session.repoFullName) {
-            displayRepo = session.repoFullName;
-            repoName = session.repoName || session.repoFullName.split('/').pop();
+        if (session && session.metadata?.repoFullName) {
+            displayRepo = session.metadata.repoFullName;
+            repoName = session.metadata.repoName || session.metadata.repoFullName.split('/').pop();
         }
     }
 

--- a/assets/javascript/neural-chat-core.js
+++ b/assets/javascript/neural-chat-core.js
@@ -90,6 +90,11 @@ window.NeuralChatCore = (function() {
                 .filter(m => m.content)
                 .map(m => ({ role: m.role, content: m.content }));
 
+            // Final sync of linkedJulesTaskId to legacy hy_neural_session_id for real-time polling compatibility
+            if (session.metadata && session.metadata.linkedJulesTaskId) {
+                localStorage.setItem('hy_neural_session_id', session.metadata.linkedJulesTaskId);
+            }
+
             await window.NeuralProviderClient.sendMessage({
                 messages: apiMessages,
                 systemPrompt: session.systemPrompt,

--- a/assets/javascript/neural-chat-sessions.js
+++ b/assets/javascript/neural-chat-sessions.js
@@ -50,7 +50,7 @@ window.loadSession = async function(id, isArchived = false) {
     }
 
     // Sync Neural Session ID for the banner
-    const neuralId = localStorage.getItem('hy_neural_session_id_' + id);
+    let neuralId = currentSession.metadata?.linkedJulesTaskId || localStorage.getItem('hy_neural_session_id_' + id);
     if (neuralId) {
         localStorage.setItem('hy_neural_session_id', neuralId);
         startJulesPolling(neuralId);


### PR DESCRIPTION
This change unifies Claude/Neural chat sessions between the Jules Panel and Standalone Chat using a single source of truth (claude_chat_sessions). It also introduces a robust linking system to associate conversations with technical Jules tasks via metadata, and adds an intelligent interception flow when sending messages without context.

---
*PR created automatically by Jules for task [17434456475982720038](https://jules.google.com/task/17434456475982720038) started by @Axlfc*