### PR TITLE
Fix Claude Neural session persistence and synchronization

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Fixed</h5>
             <ul>
+                <li><strong>Robustez de Sesiones (Claude Neural):</strong> Implementada hidratación garantizada de <code>window.sessions</code> desde <code>claude_chat_sessions</code> y protección defensiva en <code>saveSessions</code> para evitar la pérdida de datos durante el inicio o migraciones fallidas en el modo standalone.</li>
                 <li><strong>Persistencia de Mensajes (Neural Chat):</strong> Resuelto el problema donde los mensajes desaparecían al refrescar la página. Se corrigió una colisión de variables globales en <code>BroadcastChannel</code> y se añadieron llamadas de guardado garantizado durante el flujo de envío y streaming.</li>
                 <li><strong>Claude Neural Standalone Runtime:</strong> Corregida regresión crítica que impedía el envío y recepción de respuestas. Se resolvió la falta de carga del cliente de proveedor y se añadieron logs de diagnóstico exhaustivos.</li>
                 <li><strong>Indicador de Pensamiento:</strong> Restaurada la visibilidad del estado "Claude está pensando" para proporcionar feedback visual inmediato durante la generación.</li>

--- a/assets/javascript/neural-chat-jules.js
+++ b/assets/javascript/neural-chat-jules.js
@@ -44,7 +44,7 @@ window.startJulesPolling = function(sessionId) {
                 });
 
                 if (changed) {
-                    saveSessions();
+                    saveSessions(false, 'jules-polling-new-msgs');
                     renderMessages();
                 }
             }
@@ -109,7 +109,7 @@ window.analyzeJulesOutput = async function(output, isInitial = false) {
                 content: `[ANÁLISIS JULES: #${output.session_id}]\n\n${analysis}`,
                 jules_analysis: true
             });
-            saveSessions();
+            saveSessions(false, 'jules-output-analysis');
             renderMessages();
         }
     } catch (e) {

--- a/assets/javascript/neural-chat-send.js
+++ b/assets/javascript/neural-chat-send.js
@@ -65,7 +65,7 @@ window.sendMessage = async function() {
         const userMsg = { role: 'user', content: content, timestamp: Date.now() };
         if (currentSession) {
             currentSession.messages.push(userMsg);
-            saveSessions(); // [FIX 2B] Emitir inmediatamente
+            saveSessions(false, 'jules-direct-user-msg'); // [FIX 2B] Emitir inmediatamente
             renderMessages();
         }
 
@@ -128,7 +128,7 @@ window.sendMessage = async function() {
     if (currentSession && (currentSession.title === 'Nueva Conversación' || !currentSession.title) && content) {
         currentSession.title = content.substring(0, 40) + (content.length > 40 ? '...' : '');
         currentSession.updatedAt = new Date().toISOString();
-        saveSessions();
+        saveSessions(false, 'set-title');
         renderSessionList();
     }
 
@@ -180,7 +180,7 @@ window.sendMessage = async function() {
             renderMessages();
             if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] user message rendered");
             renderSessionList();
-            saveSessions();
+            saveSessions(false, 'user-message');
 
         // FEATURE #1: Thinking Animation UI
         window.thinkingIndicator.classList.remove('hidden');
@@ -202,7 +202,7 @@ window.sendMessage = async function() {
                 userMessage: content,
                 systemPrompt: dynamicSystemPrompt,
                 saveCallback: () => {
-                    saveSessions();
+                    saveSessions(false, 'core-save-callback');
                     renderSessionList();
                 },
                 skipUserMessagePush: true,
@@ -216,7 +216,7 @@ window.sendMessage = async function() {
                     renderMessages();
                     // Periodic save during streaming to prevent loss if refresh occurs
                     if (fullContent.length % 50 < token.length) {
-                        saveSessions(true); // skipSync to avoid flooding BroadcastChannel
+                        saveSessions(true, 'streaming-incremental'); // skipSync to avoid flooding BroadcastChannel
                     }
                 },
                 onDone: (fullContent) => {
@@ -225,7 +225,7 @@ window.sendMessage = async function() {
                     if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] assistant rendered");
                     renderMessages();
                     renderSessionList();
-                    saveSessions();
+                    saveSessions(false, 'assistant-done');
                     if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] send finished");
                 },
                 onError: (err) => {
@@ -298,7 +298,7 @@ window.sendMessageCustom = async function(session, config) {
         playTTS(aiContent, config);
     }
 
-    saveSessions();
+    saveSessions(false, 'custom-provider-done');
     renderMessages();
 
     // FEATURE 1: Check for session compaction
@@ -413,7 +413,7 @@ window.compactSession = async function(session) {
                     compacted: true
                 }
             ];
-            saveSessions();
+            saveSessions(false, 'compaction-done');
             if (window.currentSessionId === session.id) {
                 renderMessages();
                 showToast("Sesión compactada automáticamente", "info");
@@ -461,7 +461,7 @@ window.sendMessageImageGen = async function(session, config) {
         content: `![Generada](${imageUrl})`
     });
 
-    saveSessions();
+    saveSessions(false, 'image-gen-done');
     renderMessages();
 }
 

--- a/assets/javascript/neural-chat-sessions.js
+++ b/assets/javascript/neural-chat-sessions.js
@@ -3,9 +3,19 @@
    ════════════════════════════════════════ */
 
 window.sessions = (function() {
+    if (window.HYPENOSYS_NEURAL_DEBUG) {
+        const raw = localStorage.getItem('claude_chat_sessions');
+        if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] Storage before init:", raw ? JSON.parse(raw).length : 0, "sessions");
+    }
     try {
-        return JSON.parse(localStorage.getItem('claude_chat_sessions') || '[]');
-    } catch(e) { return []; }
+        // PRIORITY: Always initialize from claude_chat_sessions as source of truth
+        const stored = JSON.parse(localStorage.getItem('claude_chat_sessions') || '[]');
+        if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] window.sessions init count:", stored.length);
+        return Array.isArray(stored) ? stored : [];
+    } catch(e) {
+        if (window.HYPENOSYS_NEURAL_DEBUG) console.error("[Claude Chat] Failed to parse sessions during init", e);
+        return [];
+    }
 })();
 window.archivedSessions = (function() {
     try {
@@ -18,11 +28,25 @@ window.currentSendMode = 'claude'; // 'claude' or 'jules'
 window._activeTaskContext = null;
 
 // Migrate sessions if needed
-window.sessions = window.sessions.map(s => ({
-    ...s,
-    task_ref: s.task_ref || null
-}));
-localStorage.setItem('claude_chat_sessions', JSON.stringify(window.sessions));
+if (window.sessions && window.sessions.length > 0) {
+    if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] Running migration for", window.sessions.length, "sessions");
+    const migrated = window.sessions.map(s => ({
+        ...s,
+        task_ref: s.task_ref || null
+    }));
+
+    // Only update if something actually changed to avoid unnecessary writes
+    const hasChanged = JSON.stringify(window.sessions) !== JSON.stringify(migrated);
+    if (hasChanged) {
+        window.sessions = migrated;
+        localStorage.setItem('claude_chat_sessions', JSON.stringify(window.sessions));
+        if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] Migration completed and saved");
+    } else {
+        if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] Migration skipped (no-op)");
+    }
+} else if (window.HYPENOSYS_NEURAL_DEBUG) {
+    if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] Migration skipped (no sessions)");
+}
 
 window.createNewSession = function() {
     const newSession = window.NeuralChatCore.createSession({
@@ -30,7 +54,7 @@ window.createNewSession = function() {
     });
     const id = newSession.id;
     window.sessions.unshift(newSession);
-    saveSessions();
+    saveSessions(false, 'create-session');
     renderSessionList();
 
     // Clean global neural link when creating a new session
@@ -151,7 +175,8 @@ window.addEventListener('storage', (e) => {
     }
 });
 
-window.saveSessions = function(skipSync = false) {
+window.saveSessions = function(skipSync = false, reason = 'unknown') {
+    if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] saveSessions called. Reason:", reason, "skipSync:", skipSync);
     try {
         // Deduplicate sessions by ID before saving to prevent double-entries
         const uniqueSessions = [];
@@ -164,7 +189,23 @@ window.saveSessions = function(skipSync = false) {
             }
         });
 
+        // DEFENSIVE CHECK: Never overwrite with empty if we had data before and this is an implicit call
+        if (uniqueSessions.length === 0 && reason !== 'clear-all' && reason !== 'delete-session') {
+            const raw = localStorage.getItem('claude_chat_sessions');
+            if (raw) {
+                try {
+                    const stored = JSON.parse(raw);
+                    if (Array.isArray(stored) && stored.length > 0) {
+                        console.warn("[Claude Chat] blocked potentially destructive empty save. Reason:", reason);
+                        return;
+                    }
+                } catch(e) {}
+            }
+        }
+
         localStorage.setItem('claude_chat_sessions', JSON.stringify(uniqueSessions));
+        if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Chat] Storage after save:", uniqueSessions.length, "sessions");
+
         localStorage.setItem('claude_archived_sessions', JSON.stringify(window.archivedSessions));
 
         if (window.neuralSyncChannel) {
@@ -209,7 +250,7 @@ window.archiveSession = function(id) {
     const session = window.sessions.find(s => s.id === id);
     if (session) {
         session.archived = true;
-        saveSessions();
+        saveSessions(false, 'archive-session');
         renderSessionList();
 
         if (window.currentSessionId === id) {
@@ -232,7 +273,7 @@ window.unarchiveSession = function(id) {
     const session = window.sessions.find(s => s.id === id);
     if (session) {
         session.archived = false;
-        saveSessions();
+        saveSessions(false, 'unarchive-session');
         renderSessionList();
         showToast('Conversación restaurada');
     }
@@ -246,7 +287,7 @@ window.renameSession = function(id) {
     if (newTitle !== null && newTitle.trim() !== "") {
         session.title = newTitle.trim();
         session.updatedAt = new Date().toISOString();
-        saveSessions();
+        saveSessions(false, 'rename-session');
         renderSessionList();
         if (window.currentSessionId === id) {
             document.getElementById('session-title').textContent = session.title;
@@ -265,7 +306,7 @@ window.clearAllActiveSessions = function() {
         window.sessions = [];
         window.currentSessionId = null;
         localStorage.removeItem('hy_neural_session_id');
-        saveSessions();
+        saveSessions(false, 'clear-all');
         renderSessionList();
         window.chatMessages.innerHTML = '';
         document.getElementById('welcome-screen')?.classList.remove('hidden');
@@ -291,7 +332,7 @@ window.deleteSession = function(id, skipConfirm = false) {
             document.getElementById('session-title').textContent = 'Nueva Conversación';
         }
 
-        saveSessions();
+        saveSessions(false, 'delete-session');
         renderSessionList();
         showToast('Conversación eliminada');
     };

--- a/assets/javascript/neural-chat-ui.js
+++ b/assets/javascript/neural-chat-ui.js
@@ -283,7 +283,7 @@ window.saveSystemPrompt = function() {
     const currentSession = window.sessions.find(s => s.id === window.currentSessionId);
     if (currentSession) {
         currentSession.systemPrompt = val;
-        saveSessions();
+        saveSessions(false, 'save-system-prompt');
     }
     closeSystemPrompt();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
-        "playwright": "^1.61.0"
+        "playwright": "^1.61.1"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
-    "playwright": "^1.61.0"
+    "playwright": "^1.61.1"
   }
 }


### PR DESCRIPTION
This PR fixes the issue where chat sessions created in the standalone Claude Chat interface (/chat/neural/) were lost after refreshing the page or didn't sync correctly with the Jules Panel.

The root cause was identified in the initialization and migration flow of `neural-chat-sessions.js`, which was overwriting the storage with an empty array during page load due to race conditions or incorrect hydration order.

Key changes:
1. **Source of Truth**: Hardened the initialization of `window.sessions` to always use `claude_chat_sessions` from `localStorage`.
2. **Defensive Saving**: Implemented a safeguard in `saveSessions` that blocks attempts to save an empty session array if the storage previously contained data, unless explicitly triggered by a deletion or clear-all action.
3. **Idempotent Migration**: Updated the migration logic to only write back to storage if changes are actually detected, preventing unnecessary and potentially dangerous overwrites.
4. **Immediate Persistence**: Verified and ensured that all message events (user sending, assistant starting/streaming/finishing) trigger an immediate save to maintain state consistency.
5. **Debugability**: Enhanced logging under the `HYPENOSYS_NEURAL_DEBUG` flag to track the reason for each save and the state of storage during boot.

Verified the fix using automated Playwright scripts for both standalone persistence and cross-tab synchronization.

---
*PR created automatically by Jules for task [15871466915636642782](https://jules.google.com/task/15871466915636642782) started by @Axlfc*