### PR TITLE
Improve provider-aware error messaging for NVIDIA NIM

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -73,6 +73,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Fixed</h5>
             <ul>
+                <li><strong>Mensajes de Error NVIDIA NIM:</strong> Corregido el sistema de reporte de errores para el proveedor NVIDIA NIM. Ahora identifica fallos de red/CORS antes de recibir un estado HTTP y muestra un mensaje específico y accionable sobre bloqueos de origen en GitHub Pages, evitando sugerencias engañosas de VPN o validez de API Key en estos casos.</li>
                 <li><strong>Robustez de Sesiones (Claude Neural):</strong> Implementada hidratación garantizada de <code>window.sessions</code> desde <code>claude_chat_sessions</code> y protección defensiva en <code>saveSessions</code> para evitar la pérdida de datos durante el inicio o migraciones fallidas en el modo standalone.</li>
                 <li><strong>Persistencia de Mensajes (Neural Chat):</strong> Resuelto el problema donde los mensajes desaparecían al refrescar la página. Se corrigió una colisión de variables globales en <code>BroadcastChannel</code> y se añadieron llamadas de guardado garantizado durante el flujo de envío y streaming.</li>
                 <li><strong>Claude Neural Standalone Runtime:</strong> Corregida regresión crítica que impedía el envío y recepción de respuestas. Se resolvió la falta de carga del cliente de proveedor y se añadieron logs de diagnóstico exhaustivos.</li>
@@ -318,6 +319,8 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Changed</h5>
             <ul>
+                <li><strong>Clasificación de Errores Inteligente:</strong> Rediseñado el motor de excepciones de <code>NeuralProviderClient</code> para ser consciente del contexto. El diagnóstico de VPN y red local ahora se limita estrictamente a endpoints privados (localhost, 127.x, 192.x, 10.x, 100.x, .local).</li>
+                <li><strong>Sanitización Mejorada de API Keys:</strong> Actualizada la lógica de redacción de secretos para usar el prefijo <code>nvapi-***REDACTED***</code> específicamente para NVIDIA NIM, manteniendo el estándar de seguridad en logs y UI.</li>
               <li><strong>Persistencia de UI:</strong> El estado de colapso del sidebar y de los grupos de repositorios se persiste ahora localmente en el navegador.</li>
               <li><strong>Visualización de Razonamiento (Claude 3.7+):</strong> Implementado el soporte para bloques <code>thinking-block</code> en el chat integrado del Panel V2, permitiendo observar el razonamiento interno de los modelos más avanzados.</li>
               <li><strong>Análisis de Historial Integrado (V2):</strong> Refactorizado el sistema de análisis manual para que los fragmentos seleccionados del historial de Jules se inyecten directamente en el chat de V2, eliminando la dependencia de redirecciones externas.</li>

--- a/assets/javascript/neural-chat-send.js
+++ b/assets/javascript/neural-chat-send.js
@@ -241,7 +241,12 @@ window.sendMessage = async function() {
     } catch (e) {
         if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] send failed:", e.message);
         console.error('[ClaudeChat] Send error:', e);
-        const errorMsg = provider === 'ollama' ? window.ollamaDiscovery.getErrorMessage(e, config.base_url) : e.message;
+
+        // Use provider-specific logic for general catch (if it didn't come from onError)
+        let errorMsg = e.message;
+        if (provider === 'ollama' && window.ollamaDiscovery) {
+            errorMsg = window.ollamaDiscovery.getErrorMessage(e, config.base_url);
+        }
         appendSystemMessage(errorMsg, 'error');
     } finally {
         window.thinkingIndicator.classList.add('hidden');

--- a/assets/javascript/neural-provider-client.js
+++ b/assets/javascript/neural-provider-client.js
@@ -145,31 +145,69 @@ window.NeuralProviderClient = (function() {
             if (onDone) onDone(aiContent);
 
         } catch (e) {
-            console.error('[NeuralProviderClient] Error:', e);
-
-            // Sanitize error message to prevent API key leakage if it was somehow included
+            // Sanitize error message to prevent API key leakage
             let safeMessage = e.message || "Unknown error";
             if (apiKey) {
                 const escapedKey = apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                safeMessage = safeMessage.replace(new RegExp(escapedKey, 'g'), '[REDACTED]');
+                const replacement = apiKey.startsWith('nvapi-') ? 'nvapi-***REDACTED***' : '[REDACTED]';
+                safeMessage = safeMessage.replace(new RegExp(escapedKey, 'g'), replacement);
             }
 
+            console.error('[NeuralProviderClient] Error:', safeMessage);
             if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] provider call failed:", safeMessage);
+
             if (onError) {
-                // Provider-aware error messages
-                let troubleshooting = "Check VPN reachability";
+                const isNetworkFailure = safeMessage.includes('Failed to fetch') ||
+                                       safeMessage.includes('NetworkError') ||
+                                       !safeMessage.includes('Status:');
 
-                if (provider === 'ollama') {
-                    troubleshooting += ", CORS/OLLAMA_ORIGINS and local network connectivity.";
-                } else if (provider === 'nvidia_nim') {
-                    troubleshooting += ", browser CORS policy and API key validity.";
+                const isNvidiaCloud = provider === 'nvidia_nim' && baseUrl.includes('integrate.api.nvidia.com');
+                const isOllama = provider === 'ollama';
+
+                // Specific case: NVIDIA Cloud direct browser failure (CORS/Preflight)
+                if (isNvidiaCloud && isNetworkFailure) {
+                    const nimError = new Error(`NVIDIA NIM direct browser request failed before receiving an HTTP response. The endpoint/model/API key have been confirmed working outside the browser, so this points to browser/origin blocking such as CORS or preflight from GitHub Pages. Use TEST NIM DIRECT for details or configure a CORS-compatible relay endpoint.`);
+                    onError(nimError);
+                    return;
                 }
 
+                // General provider-aware troubleshooting
+                let troubleshooting = [];
+
+                // 1. Mixed Content
                 if (baseUrl.startsWith('http://') && window.location.protocol === 'https:') {
-                    troubleshooting += " (Possible Mixed Content block)";
+                    troubleshooting.push("Possible Mixed Content block (HTTP requested from HTTPS)");
                 }
 
-                const detailedError = new Error(`AI request failed for provider ${provider} at ${baseUrl}. ${safeMessage}. ${troubleshooting}`);
+                // 2. Private/Local Network (only if endpoint is private)
+                const host = baseUrl.replace(/^https?:\/\//, '').split('/')[0].split(':')[0];
+                const isPrivate = /(^127\.)|(^192\.168\.)|(^10\.)|(^172\.(1[6-9]|2[0-9]|3[0-1])\.)|(^100\.)|(^localhost)|(\.local$)/.test(host);
+
+                if (isPrivate) {
+                    troubleshooting.push("Check VPN reachability and local network connectivity");
+                }
+
+                // 3. Provider Specifics
+                if (isOllama) {
+                    troubleshooting.push("Check OLLAMA_ORIGINS and if Ollama is running");
+                } else if (provider === 'nvidia_nim') {
+                    if (!isNetworkFailure) {
+                        // We have an HTTP status if it's not a network failure
+                        if (safeMessage.includes('Status: 401') || safeMessage.includes('Status: 403')) {
+                            troubleshooting.push("Check API key validity and entitlements");
+                        } else if (safeMessage.includes('Status: 410')) {
+                            troubleshooting.push("This model has reached end-of-life (EOL)");
+                        }
+                    }
+                }
+
+                // Default if no specific troubleshooting found and it's a generic network error
+                if (troubleshooting.length === 0 && isNetworkFailure && !isNvidiaCloud) {
+                    troubleshooting.push("Check your internet connection or browser blocking policies");
+                }
+
+                const troubleshootingText = troubleshooting.length > 0 ? `. ${troubleshooting.join('. ')}.` : '';
+                const detailedError = new Error(`AI request failed for provider ${provider} at ${baseUrl}. ${safeMessage}${troubleshootingText}`);
                 onError(detailedError);
             }
         }


### PR DESCRIPTION
This PR improves the error messaging in the Neural Provider Client to be more accurate and actionable, particularly for NVIDIA NIM.

Key changes:
1. **NVIDIA Cloud Specific Error**: When a request to `integrate.api.nvidia.com` fails before an HTTP response is received (e.g., due to CORS or preflight blocking on GitHub Pages), it now shows a dedicated message explaining the browser-level restriction instead of generic VPN/API key advice.
2. **Conditional Troubleshooting**: VPN and local network reachability are now only suggested if the target endpoint is a private or local IP/hostname (e.g., 127.x, 192.168.x, 10.x, 100.x, .local).
3. **Status-Aware Guidance**: API key validity is only highlighted as a potential cause if an actual HTTP 401 or 403 status is received from the provider.
4. **Enhanced Redaction**: NVIDIA API keys starting with `nvapi-` are now redacted as `nvapi-***REDACTED***` in logs and error messages, while other keys use the standard `[REDACTED]` placeholder.
5. **Ollama Consistency**: Maintained and clarified Ollama-specific troubleshooting (OLLAMA_ORIGINS) for the Ollama provider.

These changes ensure that technical failures are correctly classified and that users receive the most relevant advice for their specific setup.

---
*PR created automatically by Jules for task [5329756554141261968](https://jules.google.com/task/5329756554141261968) started by @Axlfc*