### PR TITLE
Implement SVN Access ON/OFF toggle in repo-admin

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Added</h5>
             <ul>
+                <li><strong>SVN Access Toggle (Neural Chat & Jules Panel):</strong> Implementado un control ON/OFF para inyectar contexto del repositorio SVN (trunk/Hypenosys) en las conversaciones con Claude. Incluye detección de intención heurística (diff, log, list, info) y protecciones de configuración en <code>repo-admin</code>.</li>
                 <li><strong>Mobile AI Config (Jules Panel):</strong> Implementado un chip interactivo en el header móvil que muestra el perfil activo y abre el selector de perfiles.</li>
                 <li><strong>Drawer de Perfiles:</strong> Nueva interfaz estilo "bottom sheet" para la selección de modelos de IA en dispositivos móviles.</li>
                 <li><strong>Acceso en Config:</strong> Añadida sección de "IA Provider" en la pestaña de configuración del Jules Panel.</li>

--- a/assets/javascript/jules-panel-neural.js
+++ b/assets/javascript/jules-panel-neural.js
@@ -205,6 +205,14 @@ window.initJulesPanelNeuralChat = function() {
         }
     }
 
+    // SVN Integration Toggle
+    const svnBadge = document.getElementById('svn-status-badge');
+    if (svnBadge) {
+        if (window.JulesSvnBridge && window.JulesSvnBridge.updateSvnStatusBadge) {
+            window.JulesSvnBridge.updateSvnStatusBadge();
+        }
+    }
+
     window._julesPanelNeuralInitialized = true;
     console.log("[Jules Panel Neural] Jules Panel Neural initialized");
 }
@@ -348,8 +356,24 @@ window.sendChatV2Msg = async function() {
             }
         }
 
+        // SVN CONTEXT INJECTION
+        const svnEnabled = localStorage.getItem('hypenosys_svn_context_enabled') === 'true';
+        let svnContext = null;
+
+        if (svnEnabled && window.JulesSvnBridge?.getSvnContext) {
+            try {
+                svnContext = await Promise.race([
+                    window.JulesSvnBridge.getSvnContext(msg),
+                    new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 3500))
+                ]);
+            } catch (error) {
+                console.warn('[SvnBridge] failed; continuing without svn', error);
+                svnContext = null;
+            }
+        }
+
         const baseSystemPrompt = await window.JulesDocsBridge.buildSystemPrompt(msg, session.systemPrompt);
-        const dynamicSystemPrompt = baseSystemPrompt + (docsContext || "");
+        const dynamicSystemPrompt = baseSystemPrompt + (docsContext || "") + (svnContext || "");
 
         // Store sources for this turn
         const currentSources = window._lastDocsMetadata || [];

--- a/assets/javascript/jules-svn-bridge.js
+++ b/assets/javascript/jules-svn-bridge.js
@@ -1,0 +1,169 @@
+/**
+ * JULES SVN BRIDGE
+ * Provides SVN repository context to Neural Chat via n8n webhooks.
+ * This bridge reuses credentials and endpoints from repo-admin settings (Read-Only).
+ */
+window.JulesSvnBridge = (function() {
+
+    // Persistent state: hypenosys_svn_context_enabled
+    let _isSvnEnabled = localStorage.getItem('hypenosys_svn_context_enabled') === 'true';
+
+    // Default to false if no repo-admin settings found to avoid dead calls
+    const hasRepoSettings = !!localStorage.getItem('hypenosys_repoAdmin');
+    if (!hasRepoSettings) {
+        _isSvnEnabled = false;
+        localStorage.setItem('hypenosys_svn_context_enabled', 'false');
+    }
+
+    window.toggleSvnContext = function() {
+        if (!_isSvnEnabled) {
+            // Guard: Check if all SVN endpoints are configured before enabling
+            try {
+                const settings = JSON.parse(localStorage.getItem('hypenosys_repoAdmin') || '{}');
+                const endpoints = settings.endpoints || {};
+                const required = ['svn-list', 'svn-log', 'svn-info', 'svn-diff'];
+                const missing = required.some(k => !endpoints[k]);
+
+                if (missing) {
+                    if (window.showToast) window.showToast('SVN no configurado en repo-admin', 'amber');
+                    return;
+                }
+            } catch(e) {
+                if (window.showToast) window.showToast('Error al leer configuración SVN', 'red');
+                return;
+            }
+        }
+
+        _isSvnEnabled = !_isSvnEnabled;
+        localStorage.setItem('hypenosys_svn_context_enabled', _isSvnEnabled);
+        window.updateSvnStatusBadge();
+        if (window.showToast) window.showToast(_isSvnEnabled ? 'Contexto SVN activado' : 'Contexto SVN desactivado');
+    };
+
+    window.updateSvnStatusBadge = function() {
+        const badge = document.getElementById('svn-status-badge');
+        if (!badge) return;
+
+        badge.onclick = window.toggleSvnContext;
+        badge.style.cursor = 'pointer';
+        badge.title = _isSvnEnabled ? 'Click para desactivar contexto SVN' : 'Click para activar contexto SVN';
+
+        if (_isSvnEnabled) {
+            // Dracula Red/Pink palette for SVN ON (as per design system consistency)
+            badge.className = 'flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[9px] font-bold border border-[#ff5555]/20 bg-[#ff5555]/10 text-[#ff5555] transition-all';
+            badge.innerHTML = '<span class="w-1.5 h-1.5 rounded-full bg-[#ff5555] shadow-[0_0_5px_#ff5555]"></span> svn: on';
+        } else {
+            // Reuses exact classes from docs:off for visual parity
+            badge.className = 'flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[9px] font-bold border border-[#6272a4]/20 bg-[#6272a4]/10 text-[#6272a4] transition-all opacity-70';
+            badge.innerHTML = '<span class="w-1.5 h-1.5 rounded-full bg-[#6272a4]"></span> svn: off';
+        }
+    };
+
+    /**
+     * Isolated API Call for SVN webhooks (Read-only access to repo-admin localStorage key)
+     * No dependencies on repo-admin-*.js files to avoid side effects.
+     */
+    async function svnBridgeApiCall(endpointKey, body) {
+        let settings = {};
+        try {
+            settings = JSON.parse(localStorage.getItem('hypenosys_repoAdmin') || '{}');
+        } catch(e) { return null; }
+
+        const url = settings.endpoints ? settings.endpoints[endpointKey] : null;
+
+        if (!url) {
+            console.warn(`[SvnBridge] Endpoint "${endpointKey}" not configured in repo-admin.`);
+            return null;
+        }
+
+        try {
+            const res = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    ...body,
+                    user: settings.svnUser || 'SVN_USERNAME',
+                    password: settings.svnPass || 'SVN_PASSWORD'
+                }),
+                signal: AbortSignal.timeout(15000)
+            });
+            if (!res.ok) return null;
+            const data = await res.json();
+            return data.error ? null : data;
+        } catch (e) {
+            console.error(`[SvnBridge] API Call failed for ${endpointKey}:`, e);
+            return null;
+        }
+    }
+
+    /**
+     * getSvnContext(query)
+     *
+     * Heuristic Intent Detection:
+     * - "diff": keywords [cambios, diff, diferencia, qué cambió] -> calls svn-diff
+     * - "log": keywords [log, historial, commit, quién tocó] -> calls svn-log
+     * - "list": keywords [archivos, qué hay, lista, carpetas, estructura] -> calls svn-list
+     * - "info": keywords [info, revisión, revision, rev, estado del repo] -> calls svn-info
+     *
+     * FALLBACK: If no keywords match, returns an empty string ("") to avoid polluting
+     * the prompt with irrelevant context and to prevent unnecessary n8n traffic.
+     */
+    async function getSvnContext(userMessage) {
+        if (!_isSvnEnabled) return "";
+
+        const query = userMessage.toLowerCase();
+        let context = "\n\n## CONTEXTO SVN (trunk/Hypenosys)\n";
+        let data = null;
+
+        try {
+            if (/cambios|diff|diferencia|qué cambió|que cambio/i.test(query)) {
+                // Intent: Diff (Summary of latest changes)
+                data = await svnBridgeApiCall('svn-diff', { path: '', rev1: 'PREV', rev2: 'HEAD' });
+                if (data && data.diff) {
+                    context += "Últimos cambios detectados (svn diff):\n" + data.diff.substring(0, 2500) + "\n";
+                }
+            }
+            else if (/log|historial|commit|quién tocó|quien toco/i.test(query)) {
+                // Intent: Log (Last 5 commits)
+                data = await svnBridgeApiCall('svn-log', { path: '', limit: 5 });
+                if (data && data.log) {
+                    context += "Historial reciente de commits (svn log):\n" + data.log.map(e => `r${e.revision} | ${e.author} | ${e.date}\nMsg: ${e.message}`).join('\n---\n') + "\n";
+                }
+            }
+            else if (/archivos|qué hay|que hay|lista|carpetas|estructura/i.test(query)) {
+                // Intent: List (Root structure)
+                data = await svnBridgeApiCall('svn-list', { path: '' });
+                if (data && data.entries) {
+                    context += "Estructura de archivos en raíz (svn list):\n" + data.entries.map(e => `- ${e.name}${e.kind === 'dir' ? '/' : ''} (r${e.revision})`).join('\n') + "\n";
+                }
+            }
+            else if (/info|revisión|revision|rev|estado del repo/i.test(query)) {
+                // Intent: Info (General repo status)
+                data = await svnBridgeApiCall('svn-info', {});
+                if (data && data.revision) {
+                    context += `Repositorio en revisión: r${data.revision}\nURL: ${data.url}\nÚltimo cambio por: ${data.last_changed_author} (r${data.last_changed_rev})\n`;
+                }
+            }
+            else {
+                // FALLBACK: No intent detected
+                return "";
+            }
+
+            if (!data) return ""; // Fail-silent if API returned error
+
+            context += "\nInstrucción: Usa esta información técnica real del repositorio para responder con precisión. Si la información no es suficiente, indícalo.\n\n";
+            return context;
+
+        } catch (e) {
+            console.error("[SvnBridge] Error in getSvnContext:", e);
+            return "";
+        }
+    }
+
+    return {
+        getSvnContext,
+        toggleSvnContext: window.toggleSvnContext,
+        updateSvnStatusBadge: window.updateSvnStatusBadge,
+        get isSvnEnabled() { return localStorage.getItem('hypenosys_svn_context_enabled') === 'true'; }
+    };
+})();

--- a/assets/javascript/neural-chat-send.js
+++ b/assets/javascript/neural-chat-send.js
@@ -172,6 +172,22 @@ window.sendMessage = async function() {
                 if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] skipping docs");
             }
 
+            // SVN CONTEXT INJECTION
+            const svnEnabled = localStorage.getItem('hypenosys_svn_context_enabled') === 'true';
+            let svnContext = null;
+
+            if (svnEnabled && window.JulesSvnBridge?.getSvnContext) {
+                try {
+                    svnContext = await Promise.race([
+                        window.JulesSvnBridge.getSvnContext(content),
+                        timeoutPromise(3500)
+                    ]);
+                } catch (error) {
+                    console.warn('[SvnBridge] failed; continuing without svn', error);
+                    svnContext = null;
+                }
+            }
+
             // Optimistic UI: Add user message and render immediately
             const userMsg = { role: 'user', content: content, timestamp: Date.now() };
             currentSession.messages.push(userMsg);
@@ -193,7 +209,7 @@ window.sendMessage = async function() {
             const currentSources = window._lastDocsMetadata || [];
             window._lastDocsMetadata = null;
 
-            const dynamicSystemPrompt = baseSystemPrompt + (docsContext || "");
+            const dynamicSystemPrompt = baseSystemPrompt + (docsContext || "") + (svnContext || "");
 
             if (window.HYPENOSYS_NEURAL_DEBUG) console.log("[Claude Neural] sending to provider");
 

--- a/pages/claude-chat.html
+++ b/pages/claude-chat.html
@@ -157,6 +157,7 @@ permalink: /chat/neural/
                 </div>
             </div>
             <div class="flex items-center gap-6">
+                <div id="svn-status-badge"></div>
                 <div id="docs-status-badge"></div>
                 <div id="connection-status" class="flex items-center gap-2 text-[10px] font-black tracking-widest text-[#50fa7b] bg-[#50fa7b]/5 px-3 py-1 rounded-full border border-[#50fa7b]/20">
                     <span class="w-1.5 h-1.5 rounded-full bg-[#50fa7b] shadow-[0_0_8px_#50fa7b] animate-pulse"></span> ONLINE
@@ -391,6 +392,7 @@ permalink: /chat/neural/
 <script src="{{ '/assets/javascript/obsidian-markdown-renderer.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/hypenosys-docs-index.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/jules-docs-bridge.js' | relative_url }}"></script>
+<script src="{{ '/assets/javascript/jules-svn-bridge.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/neural-chat-ui.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/neural-chat-sessions.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/neural-chat-profiles.js' | relative_url }}?v=nim-relay-v1"></script>
@@ -576,6 +578,14 @@ permalink: /chat/neural/
             docsBadge.classList.remove('hidden');
             if (window.JulesDocsBridge && window.JulesDocsBridge.updateDocsStatusBadge) {
                 window.JulesDocsBridge.updateDocsStatusBadge();
+            }
+        }
+
+        // Initialize SVN Toggle
+        const svnBadge = document.getElementById('svn-status-badge');
+        if (svnBadge) {
+            if (window.JulesSvnBridge && window.JulesSvnBridge.updateSvnStatusBadge) {
+                window.JulesSvnBridge.updateSvnStatusBadge();
             }
         }
 

--- a/pages/jules-panel.html
+++ b/pages/jules-panel.html
@@ -628,6 +628,7 @@ permalink: /jules-panel/
     <div class="view" id="view-chat" style="padding: 0; background: #07070a; flex-direction: column; height: calc(100vh - var(--header-h)); position: relative;">
         <!-- Chat Utility Bar (Always Visible) -->
         <div style="position: absolute; top: 12px; right: 24px; z-index: 20; display: flex; gap: 8px; align-items: center;">
+            <div id="svn-status-badge"></div>
             <div id="docs-status-badge" class="hidden"></div>
             <button onclick="toggleSessionDrawer()" class="btn btn-ghost btn-sm" style="padding: 6px 12px; font-size: 11px; background: rgba(13, 13, 20, 0.8); backdrop-filter: blur(8px); border: 1px solid var(--border-accent); box-shadow: 0 0 15px rgba(124, 58, 237, 0.2);">
                 <i class="fas fa-history mr-2" style="color: var(--accent2);"></i> Sesiones
@@ -975,6 +976,7 @@ permalink: /jules-panel/
 <script src="{{ '/assets/javascript/obsidian-markdown-renderer.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/hypenosys-docs-index.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/jules-docs-bridge.js' | relative_url }}"></script>
+<script src="{{ '/assets/javascript/jules-svn-bridge.js' | relative_url }}"></script>
 <script src="{{ '/assets/javascript/neural-chat-profiles.js' | relative_url }}?v=nim-relay-v1"></script>
 <script src="{{ '/assets/javascript/jules-panel-neural.js' | relative_url }}?v=nim-relay-v1"></script>
 <script src="{{ '/assets/javascript/jules-panel-auth.js' | relative_url }}"></script>


### PR DESCRIPTION
### Implementation Summary

I have implemented a working **SVN Access ON/OFF toggle** for both the Standalone Neural Chat and the Jules Panel. This feature mirrors the existing documentation toggle mechanism and is completely isolated from other integrations like Ollama or NVIDIA NIM.

#### Files Modified/Created:
1.  **`assets/javascript/jules-svn-bridge.js`** (New): Manages SVN state, implements heuristic intent detection, and performs isolated API calls to n8n webhooks.
2.  **`assets/javascript/jules-panel-neural.js`**: Updated to initialize the SVN toggle and inject SVN context into the panel's chat flow.
3.  **`assets/javascript/neural-chat-send.js`**: Updated to inject SVN context into the standalone chat flow with a fail-open timeout.
4.  **`pages/claude-chat.html`**: Added the SVN status badge to the header.
5.  **`pages/jules-panel.html`**: Added the SVN status badge to the chat utility bar.

#### Key Features:
- **Persistence:** State is saved in `localStorage` under `hypenosys_svn_context_enabled`.
- **Heuristic Intent:** Detects keywords like "cambios", "historial", or "archivos" to decide which SVN data to fetch.
- **Safety Guards:** The toggle will not activate if SVN endpoints are not configured in the repository settings.
- **Visual Parity:** Uses the exact same design language and Dracula-themed palette as the documentation toggle.
- **Isolation:** No modifications were made to `auth.js`, Ollama discovery, or NIM catalogs.

#### Verification:
- Verified via Playwright at 390px and 1280px resolutions.
- Confirmed that SVN calls only occur when the toggle is ON and an intent is matched.
- Confirmed that no unauthorized files (auth.js, etc.) were touched.

---
*PR created automatically by Jules for task [11166660949869446936](https://jules.google.com/task/11166660949869446936) started by @Axlfc*