### PR TITLE
SVN Bridge: Path Targeting and File Content Reading

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -65,6 +65,7 @@ permalink: /CHANGELOG.html
           <div class="card-body">
             <h5 class="text-success">Added</h5>
             <ul>
+                <li><strong>SVN Bridge - Path Targeting & File Reading:</strong> Implementada la capacidad de apuntar a carpetas y archivos específicos en las consultas SVN. Se añadió el nuevo comando <code>svn-cat</code> para leer y resumir el contenido de archivos directamente en el chat.</li>
                 <li><strong>SVN Access Toggle (Neural Chat & Jules Panel):</strong> Implementado un control ON/OFF para inyectar contexto del repositorio SVN (trunk/Hypenosys) en las conversaciones con Claude. Incluye detección de intención heurística (diff, log, list, info) y protecciones de configuración en <code>repo-admin</code>.</li>
                 <li><strong>Mobile AI Config (Jules Panel):</strong> Implementado un chip interactivo en el header móvil que muestra el perfil activo y abre el selector de perfiles.</li>
                 <li><strong>Drawer de Perfiles:</strong> Nueva interfaz estilo "bottom sheet" para la selección de modelos de IA en dispositivos móviles.</li>
@@ -82,6 +83,7 @@ permalink: /CHANGELOG.html
             </ul>
             <h5 class="text-success">Changed</h5>
             <ul>
+                <li><strong>Heurística de Extracción SVN:</strong> Mejorada la detección de rutas en los mensajes del usuario, permitiendo identificar archivos por extensión o nombres de carpeta capitalizados tras la intención.</li>
                 <li><strong>Pulido de UI Neural Chat:</strong> Implementado un nuevo selector de modo Claude/Jules mediante un control segmentado premium integrado en el área de input, eliminando el estilo blanco desalineado.</li>
                 <li><strong>Puntos de Estado Semánticos:</strong> Los indicadores de sesión ahora usan colores semánticos estrictos: <strong>Verde</strong> para conversaciones normales y <strong>Morado/Violeta</strong> para sesiones vinculadas a tareas de Jules.</li>
                 <li><strong>Indicador de Sesión Activa:</strong> Se ha desacoplado el estado "activo" del color del punto, utilizando ahora un resaltado de fondo y borde en la tarjeta de la sesión seleccionada.</li>

--- a/assets/javascript/jules-svn-bridge.js
+++ b/assets/javascript/jules-svn-bridge.js
@@ -21,7 +21,7 @@ window.JulesSvnBridge = (function() {
             try {
                 const settings = JSON.parse(localStorage.getItem('hypenosys_repoAdmin') || '{}');
                 const endpoints = settings.endpoints || {};
-                const required = ['svn-list', 'svn-log', 'svn-info', 'svn-diff'];
+                const required = ['svn-list', 'svn-log', 'svn-info', 'svn-diff', 'svn-cat'];
                 const missing = required.some(k => !endpoints[k]);
 
                 if (missing) {
@@ -97,12 +97,46 @@ window.JulesSvnBridge = (function() {
     }
 
     /**
+     * Path Extraction Heuristic (Phase 2 Refined)
+     * Extracts folder/file from query tokens appearing AFTER the matched intent.
+     */
+    function extractPath(query, intentMatch) {
+        if (!intentMatch) return '';
+
+        const afterMatch = query.split(intentMatch)[1] || '';
+        const tokens = afterMatch.trim().split(/\s+/).filter(Boolean);
+
+        if (!tokens.length) return '';
+
+        for (let i = 0; i < tokens.length; i++) {
+            let token = tokens[i].replace(/[?¿!¡,.;:]/g, '');
+
+            // Client-side Sanitization: defense in depth
+            if (token.includes('..')) continue;
+
+            // Heuristic A: After "carpeta", "archivo", "fichero", "en"
+            const prevToken = i > 0 ? tokens[i-1].toLowerCase() : '';
+            if (['carpeta', 'archivo', 'fichero', 'en'].includes(prevToken)) return token;
+
+            // Heuristic B: Has file extension
+            if (/\.(cs|json|uasset|umap|cpp|h|ini|cfg|png|jpg|wav|mp3|fbx|obj|md|txt)$/i.test(token)) return token;
+
+            // Heuristic C: Capitalized word (likely Unreal/Unity folder/file), but skip first word of message
+            // Note: Since we are scanning after intentMatch, tokens[0] is NOT necessarily the first word of the message.
+            // But we already restricted scan to AFTER intentMatch.
+            if (/^[A-Z][a-zA-Z0-9_\-\/.]+$/.test(token)) return token;
+        }
+        return '';
+    }
+
+    /**
      * getSvnContext(query)
      *
      * Heuristic Intent Detection:
      * - "diff": keywords [cambios, diff, diferencia, qué cambió] -> calls svn-diff
      * - "log": keywords [log, historial, commit, quién tocó] -> calls svn-log
      * - "list": keywords [archivos, qué hay, lista, carpetas, estructura] -> calls svn-list
+     * - "read": keywords [resume, resumen, analiza, qué hace, contenido de, abre, muestra el archivo] -> calls svn-cat
      * - "info": keywords [info, revisión, revision, rev, estado del repo] -> calls svn-info
      *
      * FALLBACK: If no keywords match, returns an empty string ("") to avoid polluting
@@ -114,27 +148,53 @@ window.JulesSvnBridge = (function() {
         const query = userMessage.toLowerCase();
         let context = "\n\n## CONTEXTO SVN (trunk/Hypenosys)\n";
         let data = null;
+        let matchedIntent = null;
+        let path = '';
 
         try {
-            if (/cambios|diff|diferencia|qué cambió|que cambio/i.test(query)) {
-                // Intent: Diff (Summary of latest changes)
-                data = await svnBridgeApiCall('svn-diff', { path: '', rev1: 'PREV', rev2: 'HEAD' });
+            if (/(cambios|diff|diferencia|qué cambió|que cambio)/i.test(query)) {
+                matchedIntent = query.match(/(cambios|diff|diferencia|qué cambió|que cambio)/i)[0];
+                path = extractPath(userMessage, matchedIntent);
+                // Intent: Diff (Summary of changes)
+                data = await svnBridgeApiCall('svn-diff', { path, rev1: 'PREV', rev2: 'HEAD' });
                 if (data && data.diff) {
-                    context += "Últimos cambios detectados (svn diff):\n" + data.diff.substring(0, 2500) + "\n";
+                    let diffText = data.diff;
+                    if (diffText.length > 2500) {
+                        diffText = diffText.substring(0, 2500) + "\n[CONTENIDO TRUNCADO]";
+                    }
+                    context += `Cambios detectados en ${path || 'raíz'} (svn diff):\n` + diffText + "\n";
                 }
             }
-            else if (/log|historial|commit|quién tocó|quien toco/i.test(query)) {
+            else if (/(log|historial|commit|quién tocó|quien toco)/i.test(query)) {
+                matchedIntent = query.match(/(log|historial|commit|quién tocó|quien toco)/i)[0];
+                path = extractPath(userMessage, matchedIntent);
                 // Intent: Log (Last 5 commits)
-                data = await svnBridgeApiCall('svn-log', { path: '', limit: 5 });
+                data = await svnBridgeApiCall('svn-log', { path, limit: 5 });
                 if (data && data.log) {
-                    context += "Historial reciente de commits (svn log):\n" + data.log.map(e => `r${e.revision} | ${e.author} | ${e.date}\nMsg: ${e.message}`).join('\n---\n') + "\n";
+                    context += `Historial reciente en ${path || 'raíz'} (svn log):\n` + data.log.map(e => `r${e.revision} | ${e.author} | ${e.date}\nMsg: ${e.message}`).join('\n---\n') + "\n";
                 }
             }
-            else if (/archivos|qué hay|que hay|lista|carpetas|estructura/i.test(query)) {
-                // Intent: List (Root structure)
-                data = await svnBridgeApiCall('svn-list', { path: '' });
+            else if (/(archivos|qué hay|que hay|lista|carpetas|estructura)/i.test(query)) {
+                matchedIntent = query.match(/(archivos|qué hay|que hay|lista|carpetas|estructura)/i)[0];
+                path = extractPath(userMessage, matchedIntent);
+                // Intent: List (Structure)
+                data = await svnBridgeApiCall('svn-list', { path });
                 if (data && data.entries) {
-                    context += "Estructura de archivos en raíz (svn list):\n" + data.entries.map(e => `- ${e.name}${e.kind === 'dir' ? '/' : ''} (r${e.revision})`).join('\n') + "\n";
+                    context += `Estructura de archivos en ${path || 'raíz'} (svn list):\n` + data.entries.map(e => `- ${e.name}${e.kind === 'dir' ? '/' : ''} (r${e.revision})`).join('\n') + "\n";
+                }
+            }
+            else if (/(resume|resumen|analiza|qué hace|que hace|contenido de|abre|muestra el archivo)/i.test(query)) {
+                matchedIntent = query.match(/(resume|resumen|analiza|qué hace|que hace|contenido de|abre|muestra el archivo)/i)[0];
+                path = extractPath(userMessage, matchedIntent);
+                if (!path) return ""; // Cat requires a path
+                // Intent: Read (File content)
+                data = await svnBridgeApiCall('svn-cat', { path });
+                if (data && data.content) {
+                    let content = data.content;
+                    if (content.length > 2500) {
+                        content = content.substring(0, 2500) + "\n[CONTENIDO TRUNCADO]";
+                    }
+                    context += `Contenido del archivo ${path} (svn cat):\n` + content + "\n";
                 }
             }
             else if (/info|revisión|revision|rev|estado del repo/i.test(query)) {

--- a/assets/javascript/repo-admin-api.js
+++ b/assets/javascript/repo-admin-api.js
@@ -1,6 +1,7 @@
 /* ════════════════════════════════════════
    N8N WORKFLOWS — copy from Settings
    ════════════════════════════════════════ */
+// NOTE: This object is a static reference only used for display in the Settings UI and for copying the JSON structure to the clipboard; it is not read via any API call to dynamically create or update workflows in n8n.
 window.WORKFLOWS = {
   'svn-list': {
     name: "SVN List",
@@ -225,6 +226,53 @@ return [{'json': {'diff': result.stdout, 'error': result.stderr, 'path': path, '
       "SVN Diff": { main: [[{ node: "Respond", type: "main", index: 0 }]] }
     }
   },
+  'svn-cat': {
+    name: "SVN Cat",
+    nodes: [
+      {
+        parameters: {
+          httpMethod: ["POST"], path: "svn-cat",
+          responseMode: "responseNode",
+          options: { allowedOrigins: "https://hypenosys.github.io" }
+        },
+        type: "n8n-nodes-base.webhook", typeVersion: 2.1,
+        position: [400, -200], id: "wh-svn-cat", name: "Webhook SVN Cat"
+      },
+      {
+        parameters: {
+          language: "python",
+          code: `import subprocess
+body = items[0]['json']['body']
+path = body.get('path', '')
+rev = str(body.get('rev', 'HEAD'))
+user = body.get('user', 'SVN_USERNAME')
+pwd = body.get('password', 'SVN_PASSWORD')
+svn_url = f"svn://100.64.74.27/hypenosys/trunk/Hypenosys/{path}".rstrip('/')
+result = subprocess.run(
+  ['svn', 'cat', '-r', rev, '--username', user, '--password', pwd, '--no-auth-cache', '--non-interactive', svn_url],
+  capture_output=True, text=True, timeout=30
+)
+content = result.stdout
+truncated = False
+if len(content) > 8000:
+    content = content[:8000]
+    truncated = True
+return [{'json': {'content': content, 'truncated': truncated, 'error': result.stderr, 'path': path, 'rev': rev}}]`
+        },
+        type: "n8n-nodes-base.code", typeVersion: 2,
+        position: [600, -200], id: "code-svn-cat", name: "SVN Cat"
+      },
+      {
+        parameters: { respondWith: "json", responseBody: "={{ JSON.stringify($json) }}", options: { responseHeaders: { entries: [{ name: "Content-Type", value: "application/json" }] } } },
+        type: "n8n-nodes-base.respondToWebhook", typeVersion: 1.4,
+        position: [800, -200], id: "resp-svn-cat", name: "Respond"
+      }
+    ],
+    connections: {
+      "Webhook SVN Cat": { main: [[{ node: "SVN Cat", type: "main", index: 0 }]] },
+      "SVN Cat": { main: [[{ node: "Respond", type: "main", index: 0 }]] }
+    }
+  },
   'git-log': {
     name: "Git Log",
     nodes: [
@@ -318,6 +366,7 @@ window.saveSettings = function() {
     'svn-log': document.getElementById('cfgSvnLog').value.trim(),
     'svn-info': document.getElementById('cfgSvnInfo').value.trim(),
     'svn-diff': document.getElementById('cfgSvnDiff').value.trim(),
+    'svn-cat': document.getElementById('cfgSvnCat')?.value.trim() || ST.endpoints['svn-cat'] || '',
     'git-log': document.getElementById('cfgGitLog').value.trim(),
   };
   ST.svnUser = document.getElementById('cfgSvnUser').value.trim();

--- a/pages/repo-admin.html
+++ b/pages/repo-admin.html
@@ -301,6 +301,10 @@ permalink: /repo-admin/
         <input type="url" id="cfgSvnDiff" class="ra-input" placeholder="https://n8n.../webhook/svn-diff">
       </div>
       <div class="ra-field-group">
+        <label class="ra-label">SVN Cat webhook</label>
+        <input type="url" id="cfgSvnCat" class="ra-input" placeholder="https://n8n.../webhook/svn-cat">
+      </div>
+      <div class="ra-field-group">
         <label class="ra-label">Git Log webhook</label>
         <input type="url" id="cfgGitLog" class="ra-input" placeholder="https://n8n.../webhook/git-log">
       </div>
@@ -319,6 +323,7 @@ permalink: /repo-admin/
         <button class="ra-mini-btn" style="width:100%;margin-top:4px" onclick="copyWorkflows('svn-log')">SVN Log workflow</button>
         <button class="ra-mini-btn" style="width:100%;margin-top:4px" onclick="copyWorkflows('svn-info')">SVN Info workflow</button>
         <button class="ra-mini-btn" style="width:100%;margin-top:4px" onclick="copyWorkflows('svn-diff')">SVN Diff workflow</button>
+        <button class="ra-mini-btn" style="width:100%;margin-top:4px" onclick="copyWorkflows('svn-cat')">SVN Cat workflow</button>
         <button class="ra-mini-btn" style="width:100%;margin-top:4px" onclick="copyWorkflows('git-log')">Git Log workflow</button>
       </div>
     </div>


### PR DESCRIPTION
This update enhances the SVN Bridge by allowing users to target specific folders or files in their queries. It also introduces the ability to read and summarize file content using a new 'svn-cat' n8n workflow.

Key changes:
- Refined path extraction heuristic that scans for folder/file names after the intent keyword, identifying them by prefixes, extensions, or capitalization.
- New 'read' intent keywords: resume, resumen, analiza, qué hace, contenido de, abre, muestra el archivo.
- Client-side sanitization rejects paths containing '..'.
- Injected content is truncated to 2500 characters with a '[CONTENIDO TRUNCADO]' note.
- Added necessary UI elements in the Repo Admin Settings for the new svn-cat endpoint.
- Added static reference documentation for the WORKFLOWS object.

---
*PR created automatically by Jules for task [11758064885824656755](https://jules.google.com/task/11758064885824656755) started by @Axlfc*