### PR TITLE
Fix Global Header Dropdown Hover Gap

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -89,6 +89,7 @@ permalink: /CHANGELOG.html
                 <li><strong>NVIDIA NIM Relay Integration:</strong> Implementado soporte completo para el worker relay <code>hypenosys-gatekeeper-v2</code> para evitar bloqueos de CORS en GitHub Pages.</li>
                 <li><strong>Estabilización NVIDIA NIM:</strong> Forzado el modo <code>stream: false</code> por defecto para NVIDIA NIM y mejorada la clasificación de errores (410 EOL, fallos de red/relay).</li>
                 <li><strong>Limpieza de Headers:</strong> Eliminación garantizada del header <code>x-requested-with</code> en las peticiones a proveedores de IA para maximizar compatibilidad.</li>
+                <li><strong>Global Header Dropdown:</strong> Corregido el bug donde los menús desplegables se cerraban inesperadamente al mover el ratón hacia las opciones debido al margen superior. Se implementó un "hover bridge" mediante un pseudo-elemento <code>::before</code>.</li>
             </ul>
             <h5 class="text-success">Changed</h5>
             <ul>

--- a/assets/javascript/global-header.js
+++ b/assets/javascript/global-header.js
@@ -126,6 +126,17 @@ class GlobalHeader {
                 display: block;
             }
 
+            /* Bridge the gap between toggle and dropdown content */
+            .gh-dropdown-content::before {
+                content: '';
+                position: absolute;
+                top: -0.5rem;
+                left: 0;
+                right: 0;
+                height: 0.5rem;
+                background: transparent;
+            }
+
             .gh-dropdown-link {
                 display: flex;
                 align-items: center;

--- a/tests/repro_header_bug.spec.js
+++ b/tests/repro_header_bug.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+
+test('dropdown should stay open when moving mouse slowly from toggle to content', async ({ page }) => {
+  // We'll use index.html which should have the global header
+  await page.goto('http://localhost:4000/');
+
+  const dropdownToggle = page.locator('.gh-nav-item >> text=Plataforma');
+  const dropdownContent = page.locator('.gh-nav-item:has-text("Plataforma") .gh-dropdown-content');
+
+  // 1. Hover over the toggle
+  await dropdownToggle.hover();
+  await expect(dropdownContent).toBeVisible();
+
+  // 2. Get bounding boxes to calculate the move
+  const toggleBox = await dropdownToggle.boundingBox();
+  const contentBox = await dropdownContent.boundingBox();
+
+  // Calculate the gap center. margin-top is 0.25rem (~4px)
+  // toggleBox.y + toggleBox.height is the bottom of the toggle
+  // contentBox.y is the top of the content
+  const gapY = toggleBox.y + toggleBox.height + 2;
+  const centerX = toggleBox.x + toggleBox.width / 2;
+
+  // 3. Move mouse slowly to the gap
+  await page.mouse.move(centerX, gapY);
+
+  // 4. Check if content is still visible.
+  // If there's a bug, it might disappear here or shortly after.
+  // We wait a bit to ensure any transition/event has fired.
+  await page.waitForTimeout(200);
+
+  const isVisible = await dropdownContent.isVisible();
+  if (!isVisible) {
+    console.log('BUG DETECTED: Dropdown closed when mouse is in the gap.');
+  }
+
+  // 5. Move mouse to the content
+  await page.mouse.move(centerX, contentBox.y + 10);
+  await page.waitForTimeout(200);
+
+  await expect(dropdownContent).toBeVisible();
+});


### PR DESCRIPTION
Fixed a bug in the global header where dropdown menus would close unexpectedly when moving the mouse from the menu trigger to the dropdown content. This was caused by a 0.25rem margin-top creating a "dead zone" that triggered a mouseleave event.

Changes:
- Added a transparent `::before` pseudo-element to `.gh-dropdown-content` in `assets/javascript/global-header.js` to bridge the gap.
- Added `tests/repro_header_bug.spec.js` to verify the fix.
- Updated `CHANGELOG.html` with the fix details.
- Verified with Playwright tests and manual screenshot inspection.

---
*PR created automatically by Jules for task [7591399604098962160](https://jules.google.com/task/7591399604098962160) started by @Axlfc*